### PR TITLE
Use Δf to calculate ADC phase compensation

### DIFF
--- a/KomaMRIBase/src/datatypes/sequence/ADC.jl
+++ b/KomaMRIBase/src/datatypes/sequence/ADC.jl
@@ -115,11 +115,12 @@ function get_adc_phase_compensation(seq)
     phase = ComplexF32[]
     for i in 1:length(seq)
         if is_ADC_on(seq[i])
-            N = seq.ADC[i].N
-            ϕ = seq.ADC[i].ϕ
-            t = KomaMRIBase.times(seq.ADC[i])
-            Δf = seq.ADC[i].Δf
-            aux = exp(-1im * ϕ) .* exp.(-1im * 2π * Δf * t)
+            adc = seq.ADC[i]
+            N = adc.N
+            ϕ = adc.ϕ
+            t = times(adc)
+            Δf = adc.Δf
+            aux = exp.(-1im .* (2π .* Δf .* t .+ ϕ))
             append!(phase, aux)
         end
     end


### PR DESCRIPTION
This PR solves the issue #571 by updating the method used for ADC phase compensation, incorporating the frecuency offset.