### PR TITLE
Fix oneAPI bool indexing issues for Julia 1.11

### DIFF
--- a/KomaMRICore/src/simulation/SimMethods/BlochSimple/BlochSimple.jl
+++ b/KomaMRICore/src/simulation/SimMethods/BlochSimple/BlochSimple.jl
@@ -89,7 +89,7 @@ function run_spin_excitation!(
         ΔBz = p.Δw ./ T(2π .* γ) .- s.Δf ./ T(γ) # ΔB_0 = (B_0 - ω_rf/γ), Need to add a component here to model scanner's dB0(x,y,z)
         Bz = (s.Gx .* x .+ s.Gy .* y .+ s.Gz .* z) .+ ΔBz
         B = sqrt.(abs.(s.B1) .^ 2 .+ abs.(Bz) .^ 2)
-        B[B .== 0] .= eps(T)
+        B .+= (B .== 0) .* eps(T)
         #Spinor Rotation
         φ = T(-2π .* γ) .* (B .* s.Δt) # TODO: Use trapezoidal integration here (?),  this is just Forward Euler
         mul!(Q(φ, s.B1 ./ B, Bz ./ B), M)


### PR DESCRIPTION
This has generated too many issues and is only happening in `BlochSimple` which is not performance critical. Therefore, I am replacing the `B[B .== 0] .= eps(T)` in [line 92](https://github.com/JuliaHealth/KomaMRI.jl/blob/master/KomaMRICore/src/simulation/SimMethods/BlochSimple/BlochSimple.jl#L92C9-L92C29) by `B .+= (B .== 0) .* eps(T)` which shouldn't have any problems, but it might be a little slower.

Related issues:
- https://github.com/JuliaGPU/oneAPI.jl/issues/473
- https://github.com/JuliaGPU/oneAPI.jl/issues/461