### PR TITLE
Fix bug in `times` function when `periods` is not a scalar

### DIFF
--- a/KomaMRIBase/src/motion/TimeCurve.jl
+++ b/KomaMRIBase/src/motion/TimeCurve.jl
@@ -136,11 +136,9 @@ function times(t, per::Real)
     return per .* t
 end
 function times(t, per::AbstractVector)
-    tr      = repeat(t, length(per))
     scale   = repeat(per, inner=[length(t)])
-    offsets = repeat(vcat(0, cumsum(per)[1:end-1]), inner=[length(t)])
-    tr     .= (tr .* scale) .+ offsets
-    return tr
+    offsets = repeat(cumsum(vcat(0, per[1:end-1]*t[end])), inner=[length(t)])
+    return (repeat(t, length(per)) .* scale) .+ offsets
 end
 function unit_time(tq, t, t_unit, periodic, per::Real)
     return interpolate_times(t .* per, t_unit, periodic, tq)


### PR DESCRIPTION
While addressing issue #620 (I haven’t yet submitted any PRs related to it), I discovered a bug in the times function located in KomaMRIBase/src/motion/TimeCurve.jl. The function wasn’t behaving as intended and only worked correctly when the last element of the argument t was equal to 1. (This happens to be the case in [this example](https://juliahealth.org/KomaMRI.jl/stable/tutorial/07-RRVariability/), which is why I hadn’t detected the bug until now). This PR addresses the problem. 

It might be a good idea to register a new version of KomaMRIBase after merging this. Alternatively, we could wait until issue #620 is resolved and possibly include a few more updates to the base. Although this PR fixes a bug, it affects a relatively uncommon use case (used only for arrhythmia emulation), so releasing a new version is not urgent.