### PR TITLE
Fix cross-reference slugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ examples/5.koma_paper/comparison_accuracy/**/*.mat
 examples/5.koma_paper/comparison_accuracy/**/*.h5
 !examples/5.koma_paper/Manifest.toml
 *_w.phantom
+.julia-local/

--- a/docs/src/explanation/5-seq-events.md
+++ b/docs/src/explanation/5-seq-events.md
@@ -371,7 +371,7 @@ julia> plot_seq(seq; slider=false)
 <object type="text/html" data="../../assets/event-combination.html" style="width:100%; height:420px;"></object>
 ```
 
-Once the struct events are defined, it's important to note that to create a single block sequence, you need to provide 2D matrices of **Grad** and **RF** structs, as well as a vector of **ADC** structs as arguments in the [`Sequence`](@ref) constructor.
+Once the struct events are defined, it's important to note that to create a single block sequence, you need to provide 2D matrices of **Grad** and **RF** structs, as well as a vector of **ADC** structs as arguments in the [`Sequence`](@ref KomaMRIBase.Sequence) constructor.
 
 
 ## Algebraic manipulation

--- a/docs/src/explanation/6-simulation.md
+++ b/docs/src/explanation/6-simulation.md
@@ -8,7 +8,7 @@ The are more internal considerations in the **KomaMRI** implementation. The **Fi
 ```@raw html
 <center><img width="100%" src="../../assets/koma-solution.svg"></center>
 ```
-**Figure 1**: The sequence `seq` is discretized after calculating the required time points in the wrapper function [simulate](@ref). The time points are then divided into `Nblocks` to reduce the amount of memory used. The phantom `obj` is divided into `Nthreads`, and **KomaMRI** will use either `run_spin_excitation!` or `run_spin_precession!` depending on the regime. If an [`ADC`](@ref) object is present, the simulator will add the signal contributions of each thread to construct the acquired signal `sig[t]`. All the parameters: `Nthreads`, `Nblocks`, `Δt_rf`, and `Δt`, are passed through a dictionary called `sim_params` as an optional parameter of the simulate function.
+**Figure 1**: The sequence `seq` is discretized after calculating the required time points in the wrapper function [simulate](@ref). The time points are then divided into `Nblocks` to reduce the amount of memory used. The phantom `obj` is divided into `Nthreads`, and **KomaMRI** will use either `run_spin_excitation!` or `run_spin_precession!` depending on the regime. If an [`ADC`](@ref KomaMRIBase.ADC) object is present, the simulator will add the signal contributions of each thread to construct the acquired signal `sig[t]`. All the parameters: `Nthreads`, `Nblocks`, `Δt_rf`, and `Δt`, are passed through a dictionary called `sim_params` as an optional parameter of the simulate function.
 
 From the programming perspective, it is needed to call the [`simulate`](@ref) function with the `sim_params` dictionary keyword argument. A user can change the values of the following keys:
 

--- a/docs/src/explanation/lit-1-phantom.jl
+++ b/docs/src/explanation/lit-1-phantom.jl
@@ -6,7 +6,7 @@ import DisplayAs #hide
 # The first input argument that **KomaMRI** needs for simulating is the phantom. 
 
 # This section goes over the concept of digital phantom and shows how it applies to the specific case
-# of **KomaMRI**. We'll go into detail about the [`Phantom`](@ref) structure and its supported operations.
+# of **KomaMRI**. We'll go into detail about the [`Phantom`](@ref KomaMRIBase.Phantom) structure and its supported operations.
 
 # ## Digital Phantom
 
@@ -22,7 +22,7 @@ import DisplayAs #hide
 # Each spin is independent of the others in terms of properties, position and state.
 # This is a key feature of **KomaMRI**, as it is explained in the [Simulation](6-simulation.md) section.
 
-# Let's take a look at the definition of the [`Phantom`](@ref) struct 
+# Let's take a look at the definition of the [`Phantom`](@ref KomaMRIBase.Phantom) struct 
 # inside Koma's source code to see what it looks like:
 # ```julia
 # @with_kw mutable struct Phantom{T<:Real}
@@ -107,7 +107,7 @@ p2 = plot_phantom_map(obj[1:1000], :T2 ; height=450) #hide
 
 # ### Combination of Phantoms
 
-# In the same way, we can add two or more phantoms, resulting in another [`Phantom`](@ref) struct:
+# In the same way, we can add two or more phantoms, resulting in another [`Phantom`](@ref KomaMRIBase.Phantom) struct:
 obj2 = pelvis_phantom2D()
 obj2.x .+= 0.1; obj.x.-= 0.1 #hide
 obj_sum = obj + obj2

--- a/docs/src/how-to/3-create-your-own-phantom.md
+++ b/docs/src/how-to/3-create-your-own-phantom.md
@@ -112,7 +112,7 @@ T2 = T2*1e-3
 T2s = T2s*1e-3
 ```
 
-Finally, we can invoke the [`Phantom`](@ref) constructor. However, before doing so, we choose not to store spins where the proton density is zero to avoid unnecessary data storage. This is achieved by applying the mask `ρ.!=0` to the arrays. Additionally, please note that we set the z-position array filled with zeros.
+Finally, we can invoke the [`Phantom`](@ref KomaMRIBase.Phantom) constructor. However, before doing so, we choose not to store spins where the proton density is zero to avoid unnecessary data storage. This is achieved by applying the mask `ρ.!=0` to the arrays. Additionally, please note that we set the z-position array filled with zeros.
 ```julia
 # Define the phantom
 obj = Phantom(


### PR DESCRIPTION
 Documenter 1.16 tightened its cross-reference checks, so links like `[ADC](@ref)` and `[Phantom](@ref)` started failing because multiple headings share the same slug. This patch points those references at their concrete definitions (`KomaMRIBase.ADC`, `KomaMRIBase.Sequence`, `KomaMRIBase.Phantom`), giving Documenter unique targets again and unblocking the docs build.