### PR TITLE
Load pulseq sequences faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ examples/5.koma_paper/comparison_accuracy/**/*.h5
 !examples/5.koma_paper/Manifest.toml
 *_w.phantom
 .julia-local/
+.codex_*

--- a/KomaMRIBase/Project.toml
+++ b/KomaMRIBase/Project.toml
@@ -1,7 +1,7 @@
 name = "KomaMRIBase"
 uuid = "d0bc0b20-b151-4d03-b2a4-6ca51751cb9c"
 
-version = "0.9.8"
+version = "0.9.9"
 authors = ["Carlos Castillo Passi <cncastillo@uc.cl>"]
 
 [workspace]

--- a/KomaMRIBase/src/datatypes/Sequence.jl
+++ b/KomaMRIBase/src/datatypes/Sequence.jl
@@ -4,9 +4,9 @@
     seq = Sequence(GR, RF)
     seq = Sequence(GR, RF, ADC)
     seq = Sequence(GR, RF, ADC, DUR)
-    seq = Sequence(GR::Array{Grad,1})
-    seq = Sequence(GR::Array{Grad,1}, RF::Array{RF,1})
-    seq = Sequence(GR::Array{Grad,1}, RF::Array{RF,1}, A::ADC, DUR, DEF)
+    seq = Sequence(GR::Array{<:Grad,1})
+    seq = Sequence(GR::Array{<:Grad,1}, RF::Array{<:RF,1})
+    seq = Sequence(GR::Array{<:Grad,1}, RF::Array{<:RF,1}, A::ADC, DUR, DEF)
 
 The Sequence struct. It contains events of an MRI sequence. Most field names (except for the
 DEF field) consist of matrices or vectors, where each column index represents a sequence
@@ -26,8 +26,8 @@ block. This struct serves as an input for the simulation.
 - `seq`: (`::Sequence`) Sequence struct
 """
 mutable struct Sequence
-	GR::Array{Grad,2}		  #Sequence in (X, Y and Z) and time
-	RF::Array{RF,2}			  #RF pulses in coil and time
+	GR::Array{<:Grad,2}		  #Sequence in (X, Y and Z) and time
+	RF::Array{<:RF,2}			  #RF pulses in coil and time
 	ADC::Array{ADC,1}		  #ADC in time
 	DUR::Array{Float64,1}				  #Duration of each block, this enables delays after RF pulses to satisfy ring-down times
 	EXT::Vector{Vector{Extension}}
@@ -73,9 +73,9 @@ function Sequence(GR, RF, ADC, DUR, EXT)
 end
 
 # Other constructors
-Sequence(GR::Array{Grad,1}) = Sequence(reshape(GR,1,:))
-Sequence(GR::Array{Grad,1}, RF::Array{RF,1})= Sequence(reshape(GR, :, 1), reshape(RF, 1, :), [ADC(0, 0.0) for i in 1:size(GR, 2)])
-Sequence(GR::Array{Grad,1}, RF::Array{RF,1}, A::ADC, DUR, EXT, DEF) = Sequence(reshape(GR, :, 1), reshape(RF, 1, :), [A], Float64[DUR], [EXT],DEF)
+Sequence(GR::AbstractVector{<:Grad}) = Sequence(reshape(GR,1,:))
+Sequence(GR::AbstractVector{<:Grad}, RF::AbstractVector{<:RF})= Sequence(reshape(GR, :, 1), reshape(RF, 1, :), [ADC(0, 0.0) for i in 1:size(GR, 2)])
+Sequence(GR::AbstractVector{<:Grad}, RF::AbstractVector{<:RF}, A::ADC, DUR, EXT, DEF) = Sequence(reshape(GR, :, 1), reshape(RF, 1, :), [A], Float64[DUR], [EXT],DEF)
 Sequence() = Sequence(
     Matrix{Grad}(undef, 3, 0),
     Matrix{RF}(undef, 1, 0),

--- a/KomaMRIBase/src/datatypes/sequence/Grad.jl
+++ b/KomaMRIBase/src/datatypes/sequence/Grad.jl
@@ -75,15 +75,15 @@ julia> gr = Grad(1, 1, 0.1, 0.1, 0.2)
 julia> seq = Sequence([gr]); plot_seq(seq)
 ```
 """
-mutable struct Grad
-    A
-    T
-    rise::Real
-    fall::Real
-    delay::Real
-    first
-    last
-    Grad(A, T, rise, fall, delay, first, last) = all(T .< 0) || rise < 0 || fall < 0 || delay < 0 ? error("Gradient timings must be positive.") : new(A, T, rise, fall, delay, first, last)
+mutable struct Grad{AT,TT}
+    A::AT
+    T::TT
+    rise::Float64
+    fall::Float64
+    delay::Float64
+    first::Float64
+    last::Float64
+    Grad(A, T, rise, fall, delay, first, last) = all(T .< 0) || rise < 0 || fall < 0 || delay < 0 ? error("Gradient timings must be positive.") : new{typeof(A),typeof(T)}(A, T, rise, fall, delay, first, last)
     Grad(A, T, rise, fall, delay)              = Grad(A, T, rise, fall, delay, 0.0, 0.0)
     Grad(A, T, rise, delay)                    = Grad(A, T, rise, rise, delay, 0.0, 0.0)
     Grad(A, T, rise)                           = Grad(A, T, rise, rise, 0.0,   0.0, 0.0)
@@ -159,13 +159,13 @@ Base.show(io::IO, x::Grad) = begin
 end
 
 """
-    y = getproperty(x::Array{Grad}, f::Symbol)
+    y = getproperty(x::Array{<:Grad}, f::Symbol)
 
 Overloads Base.getproperty(). It is meant to access properties of the Grad vector `x`
 directly without the need to iterate elementwise.
 
 # Arguments
-- `x`: (`::Array{Grad}`) vector or matrix of Grad structs
+- `x`: (`::Array{<:Grad}`) vector or matrix of Grad structs
 - `f`: (`::Symbol`, opts: [`:x`, `:y`, `:z`, `:T`, `:delay`, `:rise`, `:delay`, `:dur`,
     `:A`, `f`]) input symbol that represents a property of the vector or matrix of Grad
     structs
@@ -174,7 +174,7 @@ directly without the need to iterate elementwise.
 - `y`: (`::Array{Any}`) vector or matrix with the property defined
     by the symbol `f` for all elements of the Grad vector or matrix `x`
 """
-getproperty(x::Array{Grad}, f::Symbol) = begin
+getproperty(x::AbstractArray{<:Grad}, f::Symbol) = begin
     if f == :x
         @view x[1, :]
     elseif f == :y && size(x, 1) >= 2
@@ -211,10 +211,10 @@ Base.zero(::Grad) = Grad(0.0, 0.0)
 -(x::Grad, y::Grad) = Grad(x.A .- y.A, max(x.T, y.T), max(x.rise, y.rise), max(x.fall, y.fall), max(x.delay, y.delay)) #TODO: solve this in a better way (by "stacking" gradients) issue #487
 
 # Gradient functions
-function vcat(x::Array{Grad,1}, y::Array{Grad,1})
+function vcat(x::Vector{T}, y::Vector{T}) where {T<:Grad}
     return [i == 1 ? x[j] : y[j] for i in 1:2, j in 1:length(x)]
 end
-function vcat(x::Array{Grad,1}, y::Array{Grad,1}, z::Array{Grad,1})
+function vcat(x::Vector{T}, y::Vector{T}, z::Vector{T}) where {T<:Grad}
     return [
         if i == 1
             x[j]
@@ -228,17 +228,17 @@ end
 
 """
     y = dur(x::Grad)
-    y = dur(x::Vector{Grad})
-    y = dur(x::Matrix{Grad})
+    y = dur(x::Vector{<:Grad})
+    y = dur(x::Matrix{<:Grad})
 
 Duration time in [s] of Grad struct or Grad Array.
 
 # Arguments
-- `x`: (`::Grad` or `::Vector{Grad}` or `::Matrix{Grad}`) Grad struct or Grad Array
+- `x`: (`::Grad` or `::Vector{<:Grad}` or `::Matrix{<:Grad}`) Grad struct or Grad Array
 
 # Returns
 - `y`: (`::Float64`, `[s]`) duration of the Grad struct or Grad Array
 """
 dur(x::Grad) = x.delay + x.rise + sum(x.T) + x.fall
-dur(x::Vector{Grad}) = maximum(dur.(x); dims=1)[:]
-dur(x::Matrix{Grad}) = maximum(dur.(x); dims=1)[:]
+dur(x::AbstractVector{<:Grad}) = maximum(dur.(x); dims=1)[:]
+dur(x::AbstractMatrix{<:Grad}) = maximum(dur.(x); dims=1)[:]

--- a/KomaMRIBase/src/datatypes/sequence/RF.jl
+++ b/KomaMRIBase/src/datatypes/sequence/RF.jl
@@ -42,14 +42,14 @@ julia> rf = RF(1, 1, 0, 0.2)
 julia> seq = Sequence(); seq += rf; plot_seq(seq)
 ```
 """
-mutable struct RF
-    A
-    T
-    Δf
+mutable struct RF{AT,TT,ΔFT}
+    A::AT
+    T::TT
+    Δf::ΔFT
     delay::Float64
     center::Union{Float64, Nothing}
     use::RFUse
-    RF(A, T, Δf, delay, center, use) = any(T .< 0) || delay < 0 ? error("RF timings must be non-negative.") : new(A, T, Δf, delay, center, use)
+    RF(A, T, Δf, delay, center, use) = any(T .< 0) || delay < 0 ? error("RF timings must be non-negative.") : new{typeof(A),typeof(T),typeof(Δf)}(A, T, Δf, delay, center, use)
     RF(A, T, Δf, delay, center)      = _RF_with_center_and_use(A, T, Δf,  delay; center=center)
     RF(A, T, Δf, delay)              = _RF_with_center_and_use(A, T, Δf,  delay)
     RF(A, T, Δf)                     = _RF_with_center_and_use(A, T, Δf,  0.0)
@@ -91,13 +91,13 @@ Base.show(io::IO, x::RF) = begin
 end
 
 """
-    y = getproperty(x::Array{RF}, f::Symbol)
+    y = getproperty(x::Array{<:RF}, f::Symbol)
 
 Overloads Base.getproperty(). It is meant to access properties of the RF vector `x`
 directly without the need to iterate elementwise.
 
 # Arguments
-- `x`: (`::Array{RF}`) vector or matrix of RF structs
+- `x`: (`::Array{<:RF}`) vector or matrix of RF structs
 - `f`: (`::Symbol`, opts: [`:A`, `:Bx`, `:By`, `:T`, `:Δf`, `:delay` and `:dur`]) input
     symbol that represents a property of the vector or matrix of RF structs
 
@@ -105,7 +105,7 @@ directly without the need to iterate elementwise.
 - `y`: (`::Array{Any}`) vector or matrix with the property defined by the
     symbol `f` for all elements of the RF vector or matrix `x`
 """
-getproperty(x::Matrix{RF}, f::Symbol) = begin
+getproperty(x::AbstractMatrix{<:RF}, f::Symbol) = begin
     if f == :Bx
         real.(getfield.(x, :A))
     elseif f == :By
@@ -130,20 +130,20 @@ size(r::RF, i::Int64) = 1 #To fix [r;r;;] concatenation of Julia 1.7.3
 
 """
     y = dur(x::RF)
-    y = dur(x::Vector{RF})
-    y = dur(x::Matrix{RF})
+    y = dur(x::Vector{<:RF})
+    y = dur(x::Matrix{<:RF})
 
 Duration time in [s] of RF struct or RF Array.
 
 # Arguments
-- `x`: (`::RF` or `::Vector{RF}` or `::Matrix{RF}`) RF struct or RF array
+- `x`: (`::RF` or `::Vector{<:RF}` or `::Matrix{<:RF}`) RF struct or RF array
 
 # Returns
 - `y`: (`::Float64`, [`s`]) duration of the RF struct or RF array
 """
 dur(x::RF) = x.delay + sum(x.T)
-dur(x::Vector{RF}) = maximum(dur.(x); dims=1)[:]
-dur(x::Matrix{RF}) = maximum(dur.(x); dims=1)[:]
+dur(x::AbstractVector{<:RF}) = maximum(dur.(x); dims=1)[:]
+dur(x::AbstractMatrix{<:RF}) = maximum(dur.(x); dims=1)[:]
 
 """
     rf = RF_fun(f::Function, T::Real, N::Int64)

--- a/KomaMRIFiles/Project.toml
+++ b/KomaMRIFiles/Project.toml
@@ -1,7 +1,7 @@
 name = "KomaMRIFiles"
 uuid = "fcf631a6-1c7e-4e88-9e64-b8888386d9dc"
 
-version = "0.9.10"
+version = "0.9.11"
 authors = ["Carlos Castillo Passi <cncastillo@uc.cl>"]
 
 [workspace]

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -584,7 +584,7 @@ function read_seq(filename)
     end
     # Add first and last points for gradients #320 for version <= 1.4.2
     if pulseq_version < v"1.5.0"
-        fix_first_last_grads!(blockEvents, blockDurations, eventLibraries, pulseq_version)
+        fix_first_last_grads!(blockEvents, blockDurations, eventLibraries)
     end
 
     seq = get_seq_from_blocks(blockEvents, blockDurations, eventLibraries)

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -79,12 +79,13 @@ end
 
 """
 read_blocks Read the [BLOCKS] section of a sequence file.
-   library=read_blocks(fid, blockDurationRaster, pulseq_version)
-   Read blocks from file identifier of an open MR sequence file and
-   returns block IDs, durations and delay IDs as arrays or vectors.
+   library=read_blocks(fid, pulseq_version)
+   Read blocks from file identifier of an open MR sequence file and returns
+   block IDs, block durations (in raster units) and delay IDs as arrays or vectors.
+   Either the block durations or delay IDs will be empty depending on pulseq_version.
 
 """
-function read_blocks(io, blockDurationRaster, pulseq_version)
+function read_blocks(io, pulseq_version)
     NumberBlockEvents = pulseq_version <= v"1.2.1" ? 7 : 8
     # we'll collect everything into a vector and then reshape later
     # we assume that we have at least 1000 blocks and pre-allocate for that
@@ -110,7 +111,7 @@ function read_blocks(io, blockDurationRaster, pulseq_version)
                 append!(blocks, blockEvents[3:end])
             end
             if pulseq_version >= v"1.4.0" # Explicit block duration (in units of blockDurationRaster)
-                duration = blockEvents[2] * blockDurationRaster
+                duration = blockEvents[2]
                 push!(blockDurations, Float64(duration))
             else # Implicit block duration from delay ID
                 push!(delayIDs_tmp, blockEvents[2])
@@ -464,7 +465,7 @@ function read_seq(filename)
     def = Dict()
     signature = nothing
     blockEvents = Array{Int, 2}(undef, 0, 0)
-    blockDurations = Vector{Float64}(undef, 0)
+    blockDurations_rasterUnits = Vector{Int}(undef, 0)
     delayIDs_tmp = Vector{Int}(undef, 0)
     rfLibrary = Dict()
     adcLibrary = Dict()
@@ -487,7 +488,7 @@ function read_seq(filename)
                 if pulseq_version == v"0.0.0"
                     @error "Pulseq file MUST include [VERSION] section prior to [BLOCKS] section"
                 end
-                blockEvents, blockDurations, delayIDs_tmp = read_blocks(io, def["BlockDurationRaster"], pulseq_version)
+                blockEvents, blockDurations_rasterUnits, delayIDs_tmp = read_blocks(io, pulseq_version)
             elseif  section == "[RF]"
                 if pulseq_version >= v"1.5.0"
                     rfLibrary = read_events(io, [1/γ 1 1 1 1e-6 1e-6 1 1 1 1 1]; format="%i "*"%f "^(10)*"%c ") # this is 1.5.x format
@@ -581,7 +582,10 @@ function read_seq(filename)
             block = get_block_with_delayID(blockEvents[:, i], delayIDs_tmp[i], eventLibraries)
             blockDurations[i] = dur(block)
         end
+    else
+        blockDurations = blockDurations_rasterUnits .* def["BlockDurationRaster"]
     end
+
     # Add first and last points for gradients #320 for version <= 1.4.2
     if pulseq_version < v"1.5.0"
         fix_first_last_grads!(blockEvents, blockDurations, eventLibraries)

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -90,7 +90,7 @@ function read_blocks(io, blockDurationRaster, pulseq_version)
     # we assume that we have at least 1000 blocks and pre-allocate for that
     blocks = empty!(Vector{Int}(undef, NumberBlockEvents * 1000))
     blockDurations = empty!(Vector{Float64}(undef, 1000))
-    delayIDs_tmp = empty!(Vector{Float64}(undef, 1000))
+    delayIDs_tmp = empty!(Vector{Int}(undef, 1000))
     num_lines = 0
     while true
         blockEvents = [parse(Int, d) for d in eachsplit(readline(io))]
@@ -317,7 +317,7 @@ function decompress_shape(num_samples, data; forceDecompression = false)
 end
 
 """
-    fix_first_last_grads!(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict, pulseq_version)
+    fix_first_last_grads!(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict)
 
 Updates the `eventLibraries` dictionary with new first and last points for gradients.
 
@@ -326,12 +326,12 @@ Updates the `eventLibraries` dictionary with new first and last points for gradi
 https://github.com/pulseq/pulseq/blob/v1.5.1/matlab/%2Bmr/%40Sequence/read.m#L325-L413
 - We are updating the `gradLibrary` entries with the new first and last points, making them compatible with the v1.5.x format.
 """
-function fix_first_last_grads!(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict, pulseq_version)
+function fix_first_last_grads!(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict)
     # Add first and last Pulseq points
     grad_prev_last = [0.0; 0.0; 0.0]
     for iB in 1:size(blockEvents, 2)
         eventIDs = blockEvents[:, iB];
-        block = get_block(eventIDs, blockDurations[iB], eventLibraries, pulseq_version)
+        block = get_block(eventIDs, blockDurations[iB], eventLibraries)
         processedGradIDs = zeros(1, 3);    
         for iG in 1:3
             g_id = eventIDs[2+iG]
@@ -465,6 +465,7 @@ function read_seq(filename)
     signature = nothing
     blockEvents = Array{Int, 2}(undef, 0, 0)
     blockDurations = Vector{Float64}(undef, 0)
+    delayIDs_tmp = Vector{Int}(undef, 0)
     rfLibrary = Dict()
     adcLibrary = Dict()
     tmp_delayLibrary = Dict()
@@ -577,7 +578,7 @@ function read_seq(filename)
         resize!(blockDurations, size(blockEvents, 2))
         # inefficient but convenient way to get the block durations for older versions
         for i = 1:size(blockEvents, 1)
-            block = get_block(blockEvents[:, i], delayIDs_tmp[i], eventLibraries, pulseq_version)
+            block = get_block_with_delayID(blockEvents[:, i], delayIDs_tmp[i], eventLibraries)
             blockDurations[i] = dur(block)
         end
     end
@@ -756,20 +757,19 @@ function get_ADC(adcLibrary, i)
 end
 
 """
-    seq = get_block(eventIDs, duration, eventLibraries, pulseq_version)
+    seq = get_block(eventIDs, duration, eventLibraries)
 
 Sequence definition for one block. Used internally by [`fix_first_last_grads`](@ref).
 
 # Arguments
 - `eventIDs`: (`::Vector{Int}`) event IDs for one block
-- `duration`: (`::Float64`) block duration (for versions >= 1.4.0) or delay ID (for versions < 1.4.0)
+- `duration`: (`::Float64`) block duration
 - `eventLibraries`: (`::Dict`) main dictionary of event libraries
-- `pulseq_version`: (`::VersionNumber`) Pulseq version
 
 # Returns
 - `s`: (`::Sequence`) block Sequence struct
 """
-function get_block(eventIDs, duration, eventLibraries, pulseq_version)
+function get_block(eventIDs, duration, eventLibraries)
     #Unpacking
     irf, igx, igy, igz, iadc, iext = eventIDs
     #Gradient definition
@@ -785,14 +785,47 @@ function get_block(eventIDs, duration, eventLibraries, pulseq_version)
     A, adc_dur = get_ADC(eventLibraries["adcLibrary"], iadc)
     #DUR
     max_dur = max(dur(Gx), dur(Gy), dur(Gz), dur(R[1]) + (add_half_Δt_rf) * Δt_rf/2, adc_dur)
-    if pulseq_version >= v"1.4.0" # Explicit block duration (in units of blockDurationRaster)
-        @assert duration ≈ max_dur || duration >= max_dur "Block duration must be greater than or approximately equal to the duration of the block events"
-        D = Float64[duration]
-    else # Block duration as the maximum between the delay and the duration of the block events
-        delayID = duration
-        delay = delayID > 0 ? eventLibraries["tmp_delayLibrary"][delayID]["data"][1] : 0.0
-        D = Float64[max(delay, max_dur)]
-    end
+    @assert duration ≈ max_dur || duration >= max_dur "Block duration must be greater than or approximately equal to the duration of the block events"
+    D = Float64[duration]
+    #Extensions
+    E = get_extension(eventLibraries["extensionInstanceLibrary"], eventLibraries["extensionTypeLibrary"], eventLibraries["extensionSpecLibrary"], iext)
+    # Definitition
+    DEF = Dict{String,Any}()
+    #Sequence block definition
+    return Sequence(G,R,A,D,E,DEF)
+end
+
+"""
+    seq = get_block_with_delayID(eventIDs, delayID, eventLibraries)
+
+Sequence definition for one block. For versions < 1.4.0 where the block duration is defined by the delay ID.
+
+# Arguments
+- `eventIDs`: (`::Vector{Int}`) event IDs for one block
+- `delayID`: (`::Int`) delay ID
+- `eventLibraries`: (`::Dict`) main dictionary of event libraries
+
+# Returns
+- `s`: (`::Sequence`) block Sequence struct
+"""
+function get_block_with_delayID(eventIDs, delayID, eventLibraries)
+    #Unpacking
+    irf, igx, igy, igz, iadc, iext = eventIDs
+    #Gradient definition
+    Δt_gr = eventLibraries["definitions"]["GradientRasterTime"]
+    Gx = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igx)
+    Gy = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igy)
+    Gz = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igz)
+    G = reshape([Gx;Gy;Gz],3,1) #[Gx;Gy;Gz;;]
+    #RF definition
+    Δt_rf = eventLibraries["definitions"]["RadiofrequencyRasterTime"]
+    R, add_half_Δt_rf = get_RF(eventLibraries["rfLibrary"], eventLibraries["shapeLibrary"], Δt_rf, irf)
+    #ADC definition
+    A, adc_dur = get_ADC(eventLibraries["adcLibrary"], iadc)
+    #DUR
+    max_dur = max(dur(Gx), dur(Gy), dur(Gz), dur(R[1]) + (add_half_Δt_rf) * Δt_rf/2, adc_dur)
+    delay = delayID > 0 ? eventLibraries["tmp_delayLibrary"][delayID]["data"][1] : 0.0
+    D = Float64[max(delay, max_dur)]
     #Extensions
     E = get_extension(eventLibraries["extensionInstanceLibrary"], eventLibraries["extensionTypeLibrary"], eventLibraries["extensionSpecLibrary"], iext)
     # Definitition

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -76,28 +76,52 @@ function read_signature(io)
     return has_hash ? (type = signature_type, hash = signature_hash) : nothing
 end
 
+
 """
 read_blocks Read the [BLOCKS] section of a sequence file.
-   library=read_blocks(fid) Read blocks from file identifier of an
-   open MR sequence file and return the event table.
+   library=read_blocks(fid, blockDurationRaster, pulseq_version)
+   Read blocks from file identifier of an open MR sequence file and
+   returns block IDs, durations and delay IDs as arrays or vectors.
+
 """
-function read_blocks(io, pulseq_version)
-    eventTable = Dict{Int64, Vector{Int64}}()
+function read_blocks(io, blockDurationRaster, pulseq_version)
+    NumberBlockEvents = pulseq_version <= v"1.2.1" ? 7 : 8
+    # we'll collect everything into a vector and then reshape later
+    # we assume that we have at least 1000 blocks and pre-allocate for that
+    blocks = empty!(Vector{Int}(undef, NumberBlockEvents * 1000))
+    blockDurations = empty!(Vector{Float64}(undef, 1000))
+    delayIDs_tmp = empty!(Vector{Float64}(undef, 1000))
+    num_lines = 0
     while true
-        NumberBlockEvents = pulseq_version <= v"1.2.1" ? 7 : 8
-        read_event = readline(io)
-        !isempty(read_event) || break
-        blockEvents = parse.(Int64, split(read_event))
+        blockEvents = [parse(Int, d) for d in eachsplit(readline(io))]
+        if length(blockEvents) == 0
+            # empty line. break (fixme: pulseq doesn't forbid that, I believe, but other funcs here rely on that too for detecting end of blocks block...)
+            # or maybe it forbids. p9 says 'subsequent lines...'
+            break
+        end
+        if length(blockEvents) != NumberBlockEvents
+            error("Expected $NumberBlockEvents events but got $(length(blockEvents)).")
+        end
         if blockEvents[1] != 0
             if pulseq_version <= v"1.2.1"
-                eventTable[blockEvents[1]] = Int64[blockEvents[2:end]...; 0]
+                # discard id and duration (duration treated below)
+                append!(blocks, blockEvents[3:end], 0) # append 0 for version compatibility (see assert below)
             else
-                eventTable[blockEvents[1]] = Int64[blockEvents[2:end]...]
+                append!(blocks, blockEvents[3:end])
+            end
+            if pulseq_version >= v"1.4.0" # Explicit block duration (in units of blockDurationRaster)
+                duration = blockEvents[2] * blockDurationRaster
+                push!(blockDurations, Float64(duration))
+            else # Implicit block duration from delay ID
+                push!(delayIDs_tmp, blockEvents[2])
             end
         end
-        length(blockEvents) == NumberBlockEvents || break #Break on white space
+        num_lines += 1
     end
-    return eventTable
+    reshaped_blocks = reshape(blocks, :, num_lines)
+    # we need 6 vals because we drop IDs and durations
+    @assert size(reshaped_blocks, 1) == 6 "unexpected number of fields per block"
+    return reshaped_blocks, blockDurations, delayIDs_tmp
 end
 
 """
@@ -293,26 +317,26 @@ function decompress_shape(num_samples, data; forceDecompression = false)
 end
 
 """
-    fix_first_last_grads!(obj::Dict)
+    fix_first_last_grads!(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict, pulseq_version)
 
-Updates the `obj` dictionary with new first and last points for gradients.
+Updates the `eventLibraries` dictionary with new first and last points for gradients.
 
 # Notes:
 - This function is "replicating" the following MATLAB code:
 https://github.com/pulseq/pulseq/blob/v1.5.1/matlab/%2Bmr/%40Sequence/read.m#L325-L413
 - We are updating the `gradLibrary` entries with the new first and last points, making them compatible with the v1.5.x format.
 """
-function fix_first_last_grads!(obj::Dict, pulseq_version) 
+function fix_first_last_grads!(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict, pulseq_version)
     # Add first and last Pulseq points
     grad_prev_last = [0.0; 0.0; 0.0]
-    for iB in 1:length(obj["blockEvents"])
-        eventIDs = obj["blockEvents"][iB];
-        block = get_block(obj, iB, pulseq_version)
+    for iB in 1:size(blockEvents, 2)
+        eventIDs = blockEvents[:, iB];
+        block = get_block(eventIDs, blockDurations[iB], eventLibraries, pulseq_version)
         processedGradIDs = zeros(1, 3);    
         for iG in 1:3
             g_id = eventIDs[2+iG]
             g_id > 0 || continue
-            g = obj["gradLibrary"][g_id]
+            g = eventLibraries["gradLibrary"][g_id]
             grad = g["data"]
             if g["type"] === 'g' # Arbitrary gradient waveform
                 v1_5 = length(grad) == 6 # (1)amplitude (2)first_grads (3)last_grads (4)amp_shape_id (5)time_shape_id (6)delay 
@@ -321,7 +345,7 @@ function fix_first_last_grads!(obj::Dict, pulseq_version)
                 v1_5 && continue # Already-updated (to v1.5 format) gradLibrary entry
                 # From here, we are dealing with version == 1.5.x
                 grad = v1_4 ? [grad[1]; grad_prev_last[iG]; 0.0; grad[2:end]] : [grad[1]; grad_prev_last[iG]; 0.0; grad[2]; 0; grad[3]]
-                waveform = grad[1] * decompress_shape(obj["shapeLibrary"][grad[4]]...)
+                waveform = grad[1] * decompress_shape(eventLibraries["shapeLibrary"][grad[4]]...)
                 if grad[6] > 0 # delay > 0
                     grad_prev_last[iG] = 0.0 
                 end
@@ -338,7 +362,7 @@ function fix_first_last_grads!(obj::Dict, pulseq_version)
                     continue # avoid repeated updates if the same gradient is applied on differen gradient axes
                 end
                 processedGradIDs[iG] = g_id;
-                obj["gradLibrary"][g_id]["data"] = grad # Update the gradLibrary entry
+                eventLibraries["gradLibrary"][g_id]["data"] = grad # Update the gradLibrary entry
             else # Trapezoidal gradient waveform
                 grad_prev_last[iG] = 0.0
             end
@@ -357,6 +381,60 @@ function simplify_waveforms(amp_shape, time_shape)
         time_shape = sum(time_shape)
     end
     return amp_shape, time_shape
+end
+
+"""
+    seq = get_seq_from_blocks(blockEvents, blockDurations, eventLibraries)
+
+Sequence definition from several blocks, ordered by occurrence. Used internally by [`read_seq`](@ref).
+
+# Arguments
+- `blockEvents`: (`::Array{Int, 2}`) array of block event IDs
+- `blockDurations`: (`::Vector{Float64}`) vector of block durations
+- `eventLibraries`: (`::Dict`) main dictionary of event libraries
+
+# Returns
+- `s`: (`::Sequence`) Sequence struct
+"""
+function get_seq_from_blocks(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict)
+    # Event IDs for each event class
+    ids_rf = blockEvents[1, :]
+    ids_gradx = blockEvents[2, :]
+    ids_grady = blockEvents[3, :]
+    ids_gradz = blockEvents[4, :]
+    ids_adc = blockEvents[5, :]
+    ids_ext = blockEvents[6, :]
+
+    num_blocks = size(blockEvents, 2)
+
+    # Grad events
+    Δt_gr = eventLibraries["definitions"]["GradientRasterTime"]
+    GR = Array{Grad}(undef, 3, num_blocks)
+    GR[1, :] = collect(get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, id) for id in ids_gradx)
+    GR[2, :] = collect(get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, id) for id in ids_grady)
+    GR[3, :] = collect(get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, id) for id in ids_gradz)
+
+    # RF events
+    Δt_rf = eventLibraries["definitions"]["RadiofrequencyRasterTime"]
+    RFs = empty!(Vector{RF}(undef, num_blocks))
+    append!(RFs, get_RF(eventLibraries["rfLibrary"], eventLibraries["shapeLibrary"], Δt_rf, id)[1][1, 1] for id in ids_rf)
+    RFs = reshape(RFs, 1, num_blocks)
+
+    # ADC events
+    ADCs = empty!(Vector{ADC}(undef, num_blocks))
+    append!(ADCs, (get_ADC(eventLibraries["adcLibrary"], id)[1][1] for id in ids_adc))
+
+    # Extensions
+    EXTs = Vector{Vector{Extension}}()
+    for id in ids_ext
+        append!(EXTs, get_extension(eventLibraries["extensionInstanceLibrary"], eventLibraries["extensionTypeLibrary"], eventLibraries["extensionSpecLibrary"], id))
+    end
+
+    # Definitions
+    DEFs = Dict{String,Any}()
+
+    # Sequence 
+    return Sequence(GR, RFs, ADCs, blockDurations, EXTs, DEFs)
 end
 
 """
@@ -385,7 +463,8 @@ function read_seq(filename)
     gradLibrary = Dict()
     def = Dict()
     signature = nothing
-    blockEvents = Dict()
+    blockEvents = Array{Int, 2}(undef, 0, 0)
+    blockDurations = Vector{Float64}(undef, 0)
     rfLibrary = Dict()
     adcLibrary = Dict()
     tmp_delayLibrary = Dict()
@@ -407,7 +486,7 @@ function read_seq(filename)
                 if pulseq_version == v"0.0.0"
                     @error "Pulseq file MUST include [VERSION] section prior to [BLOCKS] section"
                 end
-                blockEvents = read_blocks(io, pulseq_version)
+                blockEvents, blockDurations, delayIDs_tmp = read_blocks(io, def["BlockDurationRaster"], pulseq_version)
             elseif  section == "[RF]"
                 if pulseq_version >= v"1.5.0"
                     rfLibrary = read_events(io, [1/γ 1 1 1 1e-6 1e-6 1 1 1 1 1]; format="%i "*"%f "^(10)*"%c ") # this is 1.5.x format
@@ -456,10 +535,11 @@ function read_seq(filename)
             end
         end
     end
-    # fix trapezoidal gradients imported from older versions
+
     if pulseq_version < v"1.4.0"
-        # scan through the gradient objects and update 't'-s (trapezoids) und 'g'-s (free-shape gradients)
+        # fix trapezoidal gradients imported from older versions
         for i in keys(gradLibrary)
+            # scan through the gradient objects and update 't'-s (trapezoids) und 'g'-s (free-shape gradients)
             if gradLibrary[i]["type"] == 't'
                 #(1)amplitude (2)rise (2)flat (3)fall (4)delay
                 if gradLibrary[i]["data"][2] == 0 #rise
@@ -479,9 +559,8 @@ function read_seq(filename)
     end
     verify_signature!(filename, signature; pulseq_version=pulseq_version)
     isempty(def) && (def = DEFAULT_DEFINITIONS)
-    #Sequence
-    obj = Dict(
-        "blockEvents"=>blockEvents,
+    #Sequence libraries (basically everything except the blocks)
+    eventLibraries = Dict(
         "gradLibrary"=>gradLibrary,
         "rfLibrary"=>rfLibrary,
         "adcLibrary"=>adcLibrary,
@@ -492,19 +571,26 @@ function read_seq(filename)
         "extensionSpecLibrary"=>extensionSpecLibrary,
         "definitions"=>def
     )
+
+    if pulseq_version < v"1.4.0"
+        # initialize blockDurations
+        resize!(blockDurations, size(blockEvents, 2))
+        # inefficient but convenient way to get the block durations for older versions
+        for i = 1:size(blockEvents, 1)
+            block = get_block(blockEvents[:, i], delayIDs_tmp[i], eventLibraries, pulseq_version)
+            blockDurations[i] = dur(block)
+        end
+    end
     # Add first and last points for gradients #320 for version <= 1.4.2
     if pulseq_version < v"1.5.0"
-        fix_first_last_grads!(obj, pulseq_version)
+        fix_first_last_grads!(blockEvents, blockDurations, eventLibraries, pulseq_version)
     end
-    #Transforming Dictionary to Sequence object
-    #This should only work for Pulseq files >=1.4.0
-    seq = Sequence()
-    for i = 1:length(blockEvents)
-        seq += get_block(obj, i, pulseq_version)
-    end
+
+    seq = get_seq_from_blocks(blockEvents, blockDurations, eventLibraries)
+
     # Final details
     #Temporary hack
-    seq.DEF = merge(obj["definitions"], seq.DEF)
+    seq.DEF = merge(eventLibraries["definitions"], seq.DEF)
     # Koma specific details for reconstrucion
     seq.DEF["FileName"] = basename(filename)
     seq.DEF["PulseqVersion"] = pulseq_version
@@ -670,44 +756,45 @@ function get_ADC(adcLibrary, i)
 end
 
 """
-    seq = get_block(obj, i, pulseq_version)
+    seq = get_block(eventIDs, duration, eventLibraries, pulseq_version)
 
-Block sequence definition. Used internally by [`read_seq`](@ref).
+Sequence definition for one block. Used internally by [`fix_first_last_grads`](@ref).
 
 # Arguments
-- `obj`: (`::Dict{String, Any}`) main dictionary
-- `i`: (`::Int64`) index of a block event
+- `eventIDs`: (`::Vector{Int}`) event IDs for one block
+- `duration`: (`::Float64`) block duration (for versions >= 1.4.0) or delay ID (for versions < 1.4.0)
+- `eventLibraries`: (`::Dict`) main dictionary of event libraries
 - `pulseq_version`: (`::VersionNumber`) Pulseq version
 
 # Returns
 - `s`: (`::Sequence`) block Sequence struct
 """
-function get_block(obj, i, pulseq_version)
+function get_block(eventIDs, duration, eventLibraries, pulseq_version)
     #Unpacking
-    idur, irf, igx, igy, igz, iadc, iext = obj["blockEvents"][i]
+    irf, igx, igy, igz, iadc, iext = eventIDs
     #Gradient definition
-    Δt_gr = obj["definitions"]["GradientRasterTime"]
-    Gx = get_Grad(obj["gradLibrary"], obj["shapeLibrary"], Δt_gr, igx)
-    Gy = get_Grad(obj["gradLibrary"], obj["shapeLibrary"], Δt_gr, igy)
-    Gz = get_Grad(obj["gradLibrary"], obj["shapeLibrary"], Δt_gr, igz)
+    Δt_gr = eventLibraries["definitions"]["GradientRasterTime"]
+    Gx = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igx)
+    Gy = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igy)
+    Gz = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igz)
     G = reshape([Gx;Gy;Gz],3,1) #[Gx;Gy;Gz;;]
     #RF definition
-    Δt_rf = obj["definitions"]["RadiofrequencyRasterTime"]
-    R, add_half_Δt_rf = get_RF(obj["rfLibrary"], obj["shapeLibrary"], Δt_rf, irf)
+    Δt_rf = eventLibraries["definitions"]["RadiofrequencyRasterTime"]
+    R, add_half_Δt_rf = get_RF(eventLibraries["rfLibrary"], eventLibraries["shapeLibrary"], Δt_rf, irf)
     #ADC definition
-    A, adc_dur = get_ADC(obj["adcLibrary"], iadc)
+    A, adc_dur = get_ADC(eventLibraries["adcLibrary"], iadc)
     #DUR
     max_dur = max(dur(Gx), dur(Gy), dur(Gz), dur(R[1]) + (add_half_Δt_rf) * Δt_rf/2, adc_dur)
     if pulseq_version >= v"1.4.0" # Explicit block duration (in units of blockDurationRaster)
-        duration = idur * obj["definitions"]["BlockDurationRaster"]
         @assert duration ≈ max_dur || duration >= max_dur "Block duration must be greater than or approximately equal to the duration of the block events"
         D = Float64[duration]
     else # Block duration as the maximum between the delay and the duration of the block events
-        idelay = idur > 0 ? obj["tmp_delayLibrary"][idur]["data"][1] : 0.0
-        D = Float64[max(idelay, max_dur)]
+        delayID = duration
+        delay = delayID > 0 ? eventLibraries["tmp_delayLibrary"][delayID]["data"][1] : 0.0
+        D = Float64[max(delay, max_dur)]
     end
     #Extensions
-    E = get_extension(obj["extensionInstanceLibrary"], obj["extensionTypeLibrary"], obj["extensionSpecLibrary"], iext)
+    E = get_extension(eventLibraries["extensionInstanceLibrary"], eventLibraries["extensionTypeLibrary"], eventLibraries["extensionSpecLibrary"], iext)
     # Definitition
     DEF = Dict{String,Any}()
     #Sequence block definition

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -3,6 +3,8 @@ const DEFAULT_DEFINITIONS = Dict("BlockDurationRaster"      => 1e-5,
                                  "RadiofrequencyRasterTime" => 1e-6, 
                                  "AdcRasterTime"            => 1e-7)
 
+include("PulseqEvents.jl")
+
 """
 read_version Read the [VERSION] section of a sequence file.
    defs=read_version(fid) Read Pulseq version from file
@@ -79,81 +81,84 @@ end
 
 """
 read_blocks Read the [BLOCKS] section of a sequence file.
-   library=read_blocks(fid, pulseq_version)
-   Read blocks from file identifier of an open MR sequence file and returns
-   block IDs, block durations (in raster units) and delay IDs as arrays or vectors.
-   Either the block durations or delay IDs will be empty depending on pulseq_version.
+   library=read_blocks(fid, blockDurationRaster, pulseq_version)
+   Read blocks from file identifier of an open MR sequence file and
+   returns block IDs, durations and delay IDs as arrays or vectors.
 
 """
-function read_blocks(io, pulseq_version)
-    NumberBlockEvents = pulseq_version <= v"1.2.1" ? 7 : 8
+function read_blocks(io, block_duration_raster, pulseq_version)
+    n_block_events = pulseq_version <= v"1.2.1" ? 7 : 8
     blocks = Int[]
     blockDurations = Float64[]
     delayIDs_tmp = Int[]
-    num_lines = 0
+    num_blocks = 0
     while true
-        blockEvents = [parse(Int, d) for d in eachsplit(readline(io))]
-        if length(blockEvents) == 0
-            # empty line. break (fixme: pulseq doesn't forbid that, I believe, but other funcs here rely on that too for detecting end of blocks block...)
-            # or maybe it forbids. p9 says 'subsequent lines...'
-            break
-        end
-        if length(blockEvents) != NumberBlockEvents
-            error("Expected $NumberBlockEvents events but got $(length(blockEvents)).")
+        line = readline(io)
+        isempty(line) && break
+        blockEvents = [parse(Int, d) for d in eachsplit(line)]
+        if length(blockEvents) != n_block_events
+            error("Expected $n_block_events events but got $(length(blockEvents)).")
         end
         if blockEvents[1] != 0
             if pulseq_version <= v"1.2.1"
                 # discard id and duration (duration treated below)
-                append!(blocks, blockEvents[3:end], 0) # append 0 for version compatibility (see assert below)
+                append!(blocks, blockEvents[3:end])
+                push!(blocks, 0) # append 0 for version compatibility (see assert below)
             else
                 append!(blocks, blockEvents[3:end])
             end
             if pulseq_version >= v"1.4.0" # Explicit block duration (in units of blockDurationRaster)
-                duration = blockEvents[2]
-                push!(blockDurations, Float64(duration))
+                duration = blockEvents[2] * block_duration_raster
+                push!(blockDurations, duration)
             else # Implicit block duration from delay ID
                 push!(delayIDs_tmp, blockEvents[2])
             end
+            num_blocks += 1
         end
-        num_lines += 1
     end
-    reshaped_blocks = reshape(blocks, :, num_lines)
+    reshaped_blocks = reshape(blocks, :, num_blocks)
     # we need 6 vals because we drop IDs and durations
     @assert size(reshaped_blocks, 1) == 6 "unexpected number of fields per block"
     return reshaped_blocks, blockDurations, delayIDs_tmp
 end
 
+apply_scale(scale::Number, value::Number) = scale * value
+apply_scale(scale, value) = value
+
 """
-    events = read_events(io, scale; type=nothing, format="%i "*"%f "^(length(scale)), eventLibrary=Dict())
+    events = read_events(io, scale; format="%i "*"%f "^(length(scale)), event_library)
 
 Read an event section of a sequence file.
 
 # Arguments
 - `io`: (`::IO`) input file stream
-- `scale`: (`::Vector{Float64}`) scale vector
+- `scale`: tuple of scale factors applied to parsed fields
 
 # Keywords
-- `type`: (`::Union{Nothing, Char}`) type of the event. Only used for gradients ('t' for trapezoidal and 'g' for arbitrary)
 - `format`: (`::String`) format string
-- `eventLibrary`: (`::Dict{Int64, Dict{String, Any}}`) event library
+- `event_library`: output dictionary for the parsed event library
+- `constructor`: constructor used to normalize each parsed event row
 
 # Returns
-- `events`: (`::Dict{Int64, Dict{String, Any}}`) event library
+- `events`: parsed event library
 """
-function read_events(io, scale; type=nothing, format="%i "*"%f "^(length(scale)), eventLibrary=Dict())
-    eventLength = length(scale) + 1
+function read_events(io, scales; format="%i " * "%f " ^ length(scales), event_library, constructor=identity)
+    event_length = length(scales) + 1
     fmt = Scanf.Format(format)
-    args = Tuple([f == "%i" ? Int : (f == "%f" ? Float64 : (f == "%c" ? Char : String)) for f in split(format)])
+    args = Tuple(
+        token == "%i" ? Int : token == "%f" ? Float64 : token == "%c" ? Char : String
+        for token in split(format)
+    )
     while true
         line = readline(io)
         isempty(line) && break
         r, data... = scanf(line, fmt, args...)
-        r == eventLength || break #Break if not all values read
+        r == event_length || break #Break if not all values read
         id = floor(Int, data[1])
-        data = [d isa Number ? s*d : d for (s, d) in zip(scale, data[2:end])]
-        eventLibrary[id] = type === nothing ? Dict("data"=>data) : Dict("data"=>data, "type"=>type)
+        parsed = ntuple(i -> apply_scale(scales[i], data[i + 1]), length(scales))
+        event_library[id] = constructor(parsed)
     end
-    return eventLibrary
+    return event_library
 end
 
 """
@@ -177,7 +182,12 @@ extension TRIGGERS 1
 """
 function read_extensions(io, ext_string, ext_type::Type{<:Extension}, ext_id, extensionTypeLibrary, extensionSpecLibrary, required_extensions)
     extensionTypeLibrary[ext_id] = ext_type
-    extensionSpecLibrary[ext_id] = read_events(io, KomaMRIBase.get_scale(ext_type); format="%i "*KomaMRIBase.get_scanf_format(ext_type))
+    extensionSpecLibrary[ext_id] = read_events(
+        io,
+        Tuple(KomaMRIBase.get_scale(ext_type));
+        format="%i " * KomaMRIBase.get_scanf_format(ext_type),
+        event_library=Dict{Int, Tuple}(),
+    )
 end
 function read_extensions(io, ext_string, ext_type, ext_id, extensionTypeLibrary, extensionSpecLibrary, required_extensions)
     if ext_string in required_extensions
@@ -197,7 +207,7 @@ read_shapes Read the [SHAPES] section of a sequence file.
    open MR sequence file and return a library of shapes.
 """
 function read_shapes(io, forceConvertUncompressed)
-    shapeLibrary = Dict()
+    shapeLibrary = ShapeLibrary()
     while true #Reading shapes
         eof(io) && break
         mark(io) # Mark the position before reading the line
@@ -316,7 +326,7 @@ function decompress_shape(num_samples, data; forceDecompression = false)
 end
 
 """
-    fix_first_last_grads!(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict)
+    fix_first_last_grads!(blockEvents, blockDurations, eventLibraries)
 
 Updates the `eventLibraries` dictionary with new first and last points for gradients.
 
@@ -325,48 +335,77 @@ Updates the `eventLibraries` dictionary with new first and last points for gradi
 https://github.com/pulseq/pulseq/blob/v1.5.1/matlab/%2Bmr/%40Sequence/read.m#L325-L413
 - We are updating the `gradLibrary` entries with the new first and last points, making them compatible with the v1.5.x format.
 """
-function fix_first_last_grads!(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict)
+function fix_first_last_grads!(blockEvents, blockDurations, eventLibraries)
     # Add first and last Pulseq points
-    grad_prev_last = [0.0; 0.0; 0.0]
-    for iB in 1:size(blockEvents, 2)
-        eventIDs = blockEvents[:, iB];
-        block = get_block(eventIDs, blockDurations[iB], eventLibraries)
-        processedGradIDs = zeros(1, 3);    
-        for iG in 1:3
-            g_id = eventIDs[2+iG]
+    grad_prev_last = zeros(3)
+    updated_grad_ids = BitSet()
+    for (iB, eventIDs) in enumerate(eachcol(blockEvents))
+        block_duration = blockDurations[iB]
+        for iG in eachindex(grad_prev_last)
+            g_id = eventIDs[1 + iG]
             g_id > 0 || continue
-            g = eventLibraries["gradLibrary"][g_id]
-            grad = g["data"]
-            if g["type"] === 'g' # Arbitrary gradient waveform
-                v1_5 = length(grad) == 6 # (1)amplitude (2)first_grads (3)last_grads (4)amp_shape_id (5)time_shape_id (6)delay 
-                v1_4 = length(grad) == 4 # (1)amplitude (2)amp_shape_id (3)time_shape_id (4)delay
-                v1_3 = length(grad) == 3 # (1)amplitude (2)amp_shape_id (3)delay
-                v1_5 && continue # Already-updated (to v1.5 format) gradLibrary entry
-                # From here, we are dealing with version == 1.5.x
-                grad = v1_4 ? [grad[1]; grad_prev_last[iG]; 0.0; grad[2:end]] : [grad[1]; grad_prev_last[iG]; 0.0; grad[2]; 0; grad[3]]
-                waveform = grad[1] * decompress_shape(eventLibraries["shapeLibrary"][grad[4]]...)
-                if grad[6] > 0 # delay > 0
-                    grad_prev_last[iG] = 0.0 
-                end
-                if grad[5] != 0 # time-shaped case
-                    grad[3] = waveform[end]
-                else # uniformly-shaped case
-                    odd_step1 = [grad[2]; 2 * waveform]
-                    odd_step2 = odd_step1 .* (mod.(1:length(odd_step1), 2) * 2 .- 1)
-                    waveform_odd_rest = cumsum(odd_step2) .* (mod.(1:length(odd_step2), 2) * 2 .- 1)
-                    grad[3] = waveform_odd_rest[end]
-                end
-                grad_prev_last[iG] = dur(block.GR[iG]) + eps(Float64) < dur(block) ? 0 : grad[3] # Bookkeeping for the next gradient
-                if iG>1 && any(processedGradIDs[1:iG] .== g_id)
-                    continue # avoid repeated updates if the same gradient is applied on differen gradient axes
-                end
-                processedGradIDs[iG] = g_id;
-                eventLibraries["gradLibrary"][g_id]["data"] = grad # Update the gradLibrary entry
-            else # Trapezoidal gradient waveform
-                grad_prev_last[iG] = 0.0
-            end
+            update_first_last!(grad_prev_last, iG, eventLibraries.grad_library[g_id], block_duration, eventLibraries, updated_grad_ids, g_id)
         end
     end
+end
+
+function fix_legacy_trapezoids!(grad_library, grad_raster_time)
+    for (i, grad) in grad_library
+        grad isa TrapGradEvent || continue
+        fix_rise = grad.rise == 0 && abs(grad.amplitude) == 0 && grad.flat > 0
+        flat = fix_rise ? grad.flat - grad_raster_time : grad.flat
+        fix_delay = grad.delay == 0 && abs(grad.amplitude) == 0 && flat > 0
+        (fix_rise || fix_delay) || continue
+        grad_library[i] = TrapGradEvent(
+            grad.amplitude,
+            fix_rise ? grad_raster_time : grad.rise,
+            fix_delay ? flat - grad_raster_time : flat,
+            grad.fall,
+            fix_delay ? grad_raster_time : grad.delay,
+        )
+    end
+end
+
+function init_legacy_block_durations!(blockDurations, blockEvents, delayIDs_tmp, eventLibraries)
+    resize!(blockDurations, size(blockEvents, 2))
+    for (i, eventIDs) in enumerate(eachcol(blockEvents))
+        delayID = delayIDs_tmp[i]
+        delay = delayID > 0 ? eventLibraries.tmp_delay_library[delayID] : 0.0
+        Gx, Gy, Gz, rf, add_half_Δt_rf, adc, _ = get_block(eventIDs, eventLibraries)
+        blockDurations[i] = max(
+            delay,
+            dur(Gx),
+            dur(Gy),
+            dur(Gz),
+            dur(rf) + add_half_Δt_rf * eventLibraries.radiofrequency_raster_time / 2,
+            dur(adc),
+        )
+    end
+end
+
+function update_first_last!(grad_prev_last, iG, ::TrapGradEvent, block_duration, event_libraries, updated_grad_ids, g_id)
+    grad_prev_last[iG] = 0.0
+    return nothing
+end
+
+function update_first_last!(grad_prev_last, iG, g::ArbGradEvent, block_duration, event_libraries, updated_grad_ids, g_id)
+    if g_id ∉ updated_grad_ids
+        g.first = grad_prev_last[iG]
+        g.last = 0.0
+        waveform = g.amplitude * decompress_shape(event_libraries.shape_library[g.amp_shape_id]...)
+        if g.time_shape_id != 0 # time-shaped case
+            g.last = waveform[end]
+        else # uniformly-shaped case
+            odd_step1 = [g.first; 2 * waveform]
+            odd_step2 = odd_step1 .* (mod.(1:length(odd_step1), 2) * 2 .- 1)
+            waveform_odd_rest = cumsum(odd_step2) .* (mod.(1:length(odd_step2), 2) * 2 .- 1)
+            g.last = waveform_odd_rest[end]
+        end
+        push!(updated_grad_ids, g_id)
+    end
+    grad_duration = dur(get_Grad(g, event_libraries.shape_library, event_libraries.gradient_raster_time))
+    grad_prev_last[iG] = grad_duration + eps(Float64) < block_duration ? 0 : g.last
+    return nothing
 end
 
 """
@@ -374,12 +413,12 @@ end
 
 Simplifies the amplitude and time waveforms when time steps are uniform.
 """
-function simplify_waveforms(amp_shape, time_shape)
-    if all(x->x==time_shape[1], time_shape)
-        amp_shape = amp_shape
-        time_shape = sum(time_shape)
-    end
-    return amp_shape, time_shape
+@inline simplify_waveforms(amp_shape, time_shape::Real) = amp_shape, time_shape
+
+function simplify_waveforms(amp_shape, time_shape::AbstractVector{<:Real})
+    isempty(time_shape) && return amp_shape, time_shape
+    all(==(time_shape[1]), time_shape) || return amp_shape, time_shape
+    return amp_shape, sum(time_shape)
 end
 
 """
@@ -390,43 +429,26 @@ Sequence definition from several blocks, ordered by occurrence. Used internally 
 # Arguments
 - `blockEvents`: (`::Array{Int, 2}`) array of block event IDs
 - `blockDurations`: (`::Vector{Float64}`) vector of block durations
-- `eventLibraries`: (`::Dict`) main dictionary of event libraries
+- `eventLibraries`: (`::PulseqEventLibraries`) main dictionary of event libraries
 
 # Returns
 - `s`: (`::Sequence`) Sequence struct
 """
-function get_seq_from_blocks(blockEvents::Array{Int, 2}, blockDurations::Vector{Float64}, eventLibraries::Dict)
-    # Event IDs for each event class
-    ids_rf = blockEvents[1, :]
-    ids_gradx = blockEvents[2, :]
-    ids_grady = blockEvents[3, :]
-    ids_gradz = blockEvents[4, :]
-    ids_adc = blockEvents[5, :]
-    ids_ext = blockEvents[6, :]
-
+function get_seq_from_blocks(blockEvents, blockDurations, eventLibraries)
     num_blocks = size(blockEvents, 2)
+    GR = Matrix{Grad}(undef, 3, num_blocks)
+    RFs = Matrix{RF}(undef, 1, num_blocks)
+    ADCs = Vector{ADC}(undef, num_blocks)
+    EXTs = Vector{Vector{Extension}}(undef, num_blocks)
 
-    # Grad events
-    Δt_gr = eventLibraries["definitions"]["GradientRasterTime"]
-    GR = Array{Grad}(undef, 3, num_blocks)
-    GR[1, :] = collect(get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, id) for id in ids_gradx)
-    GR[2, :] = collect(get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, id) for id in ids_grady)
-    GR[3, :] = collect(get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, id) for id in ids_gradz)
-
-    # RF events
-    Δt_rf = eventLibraries["definitions"]["RadiofrequencyRasterTime"]
-    RFs = RF[]
-    append!(RFs, get_RF(eventLibraries["rfLibrary"], eventLibraries["shapeLibrary"], Δt_rf, id)[1][1, 1] for id in ids_rf)
-    RFs = reshape(RFs, 1, num_blocks)
-
-    # ADC events
-    ADCs = ADC[]
-    append!(ADCs, (get_ADC(eventLibraries["adcLibrary"], id)[1][1] for id in ids_adc))
-
-    # Extensions
-    EXTs = Vector{Vector{Extension}}()
-    for id in ids_ext
-        append!(EXTs, get_extension(eventLibraries["extensionInstanceLibrary"], eventLibraries["extensionTypeLibrary"], eventLibraries["extensionSpecLibrary"], id))
+    for (i, eventIDs) in enumerate(eachcol(blockEvents))
+        Gx, Gy, Gz, rf, _, adc, ext = get_block(eventIDs, eventLibraries)
+        GR[1, i] = Gx
+        GR[2, i] = Gy
+        GR[3, i] = Gz
+        RFs[1, i] = rf
+        ADCs[i] = adc
+        EXTs[i] = ext
     end
 
     # Definitions
@@ -459,24 +481,24 @@ julia> plot_seq(seq)
 function read_seq(filename)
     @info "Loading sequence $(basename(filename)) ..."
     pulseq_version = v"0.0.0"
-    gradLibrary = Dict()
-    def = Dict()
+    gradLibrary = Dict{Int, GradEvent}()
+    def = Dict{String, Any}()
     signature = nothing
     blockEvents = Array{Int, 2}(undef, 0, 0)
-    blockDurations_rasterUnits = Vector{Int}(undef, 0) 
-    delayIDs_tmp = Vector{Int}(undef, 0)
-    rfLibrary = Dict()
-    adcLibrary = Dict()
-    tmp_delayLibrary = Dict()
-    shapeLibrary = Dict()
-    extensionInstanceLibrary = Dict()
-    extensionTypeLibrary = Dict()
-    extensionSpecLibrary = Dict()
+    blockDurations = Vector{Float64}(undef, 0)
+    delayIDs_tmp = Int[]
+    rfLibrary = Dict{Int, RFEvent}()
+    adcLibrary = Dict{Int, ADCEvent}()
+    tmp_delayLibrary = Dict{Int, Float64}()
+    shapeLibrary = ShapeLibrary()
+    extensionInstanceLibrary = Dict{Int, ExtensionInstanceEvent}()
+    extensionTypeLibrary = Dict{Int, Type{<:Extension}}()
+    extensionSpecLibrary = Dict{Int, Dict{Int, Tuple}}()
     #Reading file and storing data
     open(filename) do io
         while !eof(io)
             section = readline(io)
-            if typeof(section) == String && (isempty(section) || section[1] == '#')
+            if isempty(section) || section[1] == '#'
                 #skip useless line
             elseif section == "[DEFINITIONS]"
                 def = read_definitions(io)
@@ -486,41 +508,42 @@ function read_seq(filename)
                 if pulseq_version == v"0.0.0"
                     @error "Pulseq file MUST include [VERSION] section prior to [BLOCKS] section"
                 end
-                blockEvents, blockDurations_rasterUnits, delayIDs_tmp = read_blocks(io, pulseq_version)
+                block_duration_raster = get(def, "BlockDurationRaster", DEFAULT_DEFINITIONS["BlockDurationRaster"])
+                blockEvents, blockDurations, delayIDs_tmp = read_blocks(io, block_duration_raster, pulseq_version)
             elseif  section == "[RF]"
                 if pulseq_version >= v"1.5.0"
-                    rfLibrary = read_events(io, [1/γ 1 1 1 1e-6 1e-6 1 1 1 1 1]; format="%i "*"%f "^(10)*"%c ") # this is 1.5.x format
+                    rfLibrary = read_events(io, (1 / γ, 1, 1, 1, 1e-6, 1e-6, 1, 1, 1, 1, 1); format="%i " * "%f " ^ 10 * "%c ", event_library=rfLibrary, constructor=RFEvent) # this is 1.5.x format
                 elseif pulseq_version >= v"1.4.0"
-                    rfLibrary = read_events(io, [1/γ 1 1 1 1e-6 1 1]) # this is 1.4.x format
+                    rfLibrary = read_events(io, (1 / γ, 1, 1, 1, 1e-6, 1, 1); event_library=rfLibrary, constructor=RFEvent) # this is 1.4.x format
                 else
-                    rfLibrary = read_events(io, [1/γ 1 1 1e-6 1 1]) # this is 1.3.x and below
+                    rfLibrary = read_events(io, (1 / γ, 1, 1, 1e-6, 1, 1); event_library=rfLibrary, constructor=RFEvent) # this is 1.3.x and below
                     # we will have to scan through the library later after all the shapes have been loaded
                 end
             elseif  section == "[GRADIENTS]"
                 if pulseq_version >= v"1.5.0"
-                    gradLibrary = read_events(io, [1/γ 1/γ 1/γ 1 1 1e-6]; type='g', eventLibrary=gradLibrary) # this is 1.5.x format
+                    gradLibrary = read_events(io, (1 / γ, 1 / γ, 1 / γ, 1, 1, 1e-6); event_library=gradLibrary, constructor=ArbGradEvent) # this is 1.5.x format
                 elseif pulseq_version >= v"1.4.0"
-                    gradLibrary = read_events(io, [1/γ 1 1 1e-6]; type='g', eventLibrary=gradLibrary) # this is 1.4.x format
+                    gradLibrary = read_events(io, (1 / γ, 1, 1, 1e-6); event_library=gradLibrary, constructor=ArbGradEvent) # this is 1.4.x format
                 else
-                    gradLibrary = read_events(io, [1/γ 1 1e-6]; type='g', eventLibrary=gradLibrary) # this is 1.3.x and below
+                    gradLibrary = read_events(io, (1 / γ, 1, 1e-6); event_library=gradLibrary, constructor=ArbGradEvent) # this is 1.3.x and below
                 end
             elseif  section == "[TRAP]"
-                gradLibrary = read_events(io, [1/γ 1e-6 1e-6 1e-6 1e-6]; type='t', eventLibrary=gradLibrary);
+                gradLibrary = read_events(io, (1 / γ, 1e-6, 1e-6, 1e-6, 1e-6); event_library=gradLibrary, constructor=TrapGradEvent)
             elseif  section == "[ADC]"
                 if pulseq_version >= v"1.5.0"
-                    adcLibrary = read_events(io, [1 1e-9 1e-6 1 1 1 1 1]) # this is 1.5.x format
+                    adcLibrary = read_events(io, (1, 1e-9, 1e-6, 1, 1, 1, 1, 1); event_library=adcLibrary, constructor=ADCEvent) # this is 1.5.x format
                 else
-                    adcLibrary = read_events(io, [1 1e-9 1e-6 1 1]) # this is 1.4.x and below
+                    adcLibrary = read_events(io, (1, 1e-9, 1e-6, 1, 1); event_library=adcLibrary, constructor=ADCEvent) # this is 1.4.x and below
                 end
             elseif  section == "[DELAYS]"
                 if pulseq_version >= v"1.4.0"
                     @error "Pulseq file revision 1.4.0 and above MUST NOT contain [DELAYS] section"
                 end
-                tmp_delayLibrary = read_events(io, 1e-6);
+                tmp_delayLibrary = read_events(io, (1e-6,); event_library=tmp_delayLibrary, constructor=first);
             elseif  section == "[SHAPES]"
                 shapeLibrary = read_shapes(io, (pulseq_version.major == 1 && pulseq_version.minor < 4))
             elseif  section == "[EXTENSIONS]"
-                extensionInstanceLibrary = read_events(io, [1 1 1]; format="%i "*"%i "^(3), eventLibrary=extensionInstanceLibrary)
+                extensionInstanceLibrary = read_events(io, (1, 1, 1); format="%i " * "%i " ^ 3, event_library=extensionInstanceLibrary, constructor=ExtensionInstanceEvent)
             elseif  section == "[SIGNATURE]"
                 signature = read_signature(io)
             elseif startswith(section, "extension")
@@ -536,54 +559,29 @@ function read_seq(filename)
         end
     end
 
+    # fix trapezoidal gradients imported from older versions
     if pulseq_version < v"1.4.0"
-        # fix trapezoidal gradients imported from older versions
-        for i in keys(gradLibrary)
-            # scan through the gradient objects and update 't'-s (trapezoids) und 'g'-s (free-shape gradients)
-            if gradLibrary[i]["type"] == 't'
-                #(1)amplitude (2)rise (2)flat (3)fall (4)delay
-                if gradLibrary[i]["data"][2] == 0 #rise
-                    if abs(gradLibrary[i]["data"][1]) == 0 && gradLibrary[i]["data"][3] > 0
-                        gradLibrary[i]["data"][3] -= def["gradRasterTime"]
-                        gradLibrary[i]["data"][2]  = def["gradRasterTime"]
-                    end
-                end
-                if gradLibrary[i]["data"][4] == 0 #delay
-                    if abs(gradLibrary[i]["data"][1]) == 0 && gradLibrary[i]["data"][3] > 0
-                        gradLibrary[i]["data"][3] -= def["gradRasterTime"]
-                        gradLibrary[i]["data"][4]  = def["gradRasterTime"]
-                    end
-                end
-            end
-        end
+        grad_raster_time = get(def, "gradRasterTime", get(def, "GradientRasterTime", DEFAULT_DEFINITIONS["GradientRasterTime"]))
+        fix_legacy_trapezoids!(gradLibrary, grad_raster_time)
     end
     verify_signature!(filename, signature; pulseq_version=pulseq_version)
     isempty(def) && (def = DEFAULT_DEFINITIONS)
     #Sequence libraries (basically everything except the blocks)
-    eventLibraries = Dict(
-        "gradLibrary"=>gradLibrary,
-        "rfLibrary"=>rfLibrary,
-        "adcLibrary"=>adcLibrary,
-        "tmp_delayLibrary"=>tmp_delayLibrary,
-        "shapeLibrary"=>shapeLibrary,
-        "extensionInstanceLibrary"=>extensionInstanceLibrary,
-        "extensionTypeLibrary"=>extensionTypeLibrary,
-        "extensionSpecLibrary"=>extensionSpecLibrary,
-        "definitions"=>def
+    eventLibraries = PulseqEventLibraries(
+        gradLibrary,
+        rfLibrary,
+        adcLibrary,
+        tmp_delayLibrary,
+        shapeLibrary,
+        extensionInstanceLibrary,
+        extensionTypeLibrary,
+        extensionSpecLibrary,
+        def,
     )
 
     if pulseq_version < v"1.4.0"
-        # inefficient but convenient way to get the block durations for older versions
-        num_blocks = size(blockEvents, 2)
-        blockDurations = Vector{Float64}(undef, num_blocks)
-        for i = 1:num_blocks
-            block = get_block_with_delayID(blockEvents[:, i], delayIDs_tmp[i], eventLibraries)
-            blockDurations[i] = dur(block)
-        end
-    else
-        blockDurations = blockDurations_rasterUnits .* def["BlockDurationRaster"]
+        init_legacy_block_durations!(blockDurations, blockEvents, delayIDs_tmp, eventLibraries)
     end
-
     # Add first and last points for gradients #320 for version <= 1.4.2
     if pulseq_version < v"1.5.0"
         fix_first_last_grads!(blockEvents, blockDurations, eventLibraries)
@@ -593,7 +591,7 @@ function read_seq(filename)
 
     # Final details
     #Temporary hack
-    seq.DEF = merge(eventLibraries["definitions"], seq.DEF)
+    seq.DEF = merge(eventLibraries.definitions, seq.DEF)
     # Koma specific details for reconstrucion
     seq.DEF["FileName"] = basename(filename)
     seq.DEF["PulseqVersion"] = pulseq_version
@@ -613,8 +611,8 @@ end
 Reads the gradient. It is used internally by [`get_block`](@ref).
 
 # Arguments
-- `gradLibrary`: (`::Dict{K, V}`) the "gradLibrary" dictionary
-- `shapeLibrary`: (`::Dict{K, V}`) the "shapeLibrary" dictionary
+- `gradLibrary`: (`::Dict{Int, GradEvent}`) the "gradLibrary" dictionary
+- `shapeLibrary`: (`::ShapeLibrary`) the "shapeLibrary" dictionary
 - `Δt_gr`: (`::Float64`, `[s]`) gradient raster time
 - `i`: (`::Int64`) index of the axis in the block event
 
@@ -622,79 +620,68 @@ Reads the gradient. It is used internally by [`get_block`](@ref).
 - `grad`: (::Grad) Gradient struct
 """
 function get_Grad(gradLibrary, shapeLibrary, Δt_gr, i)
-    gr = Grad(0.0,0.0)
-    haskey(gradLibrary, i) || return gr
-    if gradLibrary[i]["type"] === 't' # Trapezoidal gradient waveform
-        #(1)amplitude (2)rise (3)flat (4)fall (5)delay
-        g_A, g_rise, g_T, g_fall, g_delay = gradLibrary[i]["data"]
-        gr = Grad(g_A,g_T,g_rise,g_fall,g_delay,0.0,0.0)
-    elseif gradLibrary[i]["type"] === 'g' # Arbitrary gradient waveform
-        g = gradLibrary[i]["data"]
-        v1_5 = length(g) == 6 # (1)amplitude (2)first_grads (3)last_grads (4)amp_shape_id (5)time_shape_id (6)delay 
-        v1_4 = length(g) == 4 # (1)amplitude (2)amp_shape_id (3)time_shape_id (4)delay
-        v1_3 = length(g) == 3 # (1)amplitude (2)amp_shape_id (3)delay
-        amplitude     =  g[1]
-        first_grads   =  v1_5 ? g[2] : 0.0
-        last_grads    =  v1_5 ? g[3] : 0.0
-        amp_shape_id  = (v1_5 ? g[4] : g[2]) |> x->floor(Int64,x)
-        time_shape_id = (v1_5 ? g[5] : (v1_4 ? g[3] : 0)) |> x->floor(Int64,x)
-        delay         =  v1_5 ? g[6] : (v1_4 ? g[4] : g[3])
-        #Amplitude
-        gA = amplitude * decompress_shape(shapeLibrary[amp_shape_id]...)
-        Ngr = length(gA) - 1
-        #Creating timings
-        if time_shape_id == 0 #no time waveform. Default time raster
-            gT = Ngr * Δt_gr
-            rise, fall = Δt_gr/2, Δt_gr/2
-        elseif time_shape_id == -1 #New in pulseq 1.5.x: no time waveform. 1/2 of the default time raster
-            gT = Ngr * Δt_gr / 2
-            rise, fall = Δt_gr/2, Δt_gr/2
-        else
-            gt = decompress_shape(shapeLibrary[time_shape_id]...)
-            gt[1] == 0 || @warn "Gradient time shape $time_shape_id starting at a non-zero value $(gt[1]). This is not recommended and may not be supported properly\n (see https://github.com/pulseq/pulseq/issues/188#issuecomment-3541588756) " maxlog=1
-            delay += gt[1] * Δt_gr # offset due to the shape starting at a non-zero value. This case 
-            gT = diff(gt) * Δt_gr
-            rise, fall = 0.0, 0.0
-        end
-        gA, gT = simplify_waveforms(gA, gT)
-        gr = Grad(gA, gT, rise, fall, delay, first_grads, last_grads)
+    haskey(gradLibrary, i) || return Grad(0.0, 0.0)
+    return get_Grad(gradLibrary[i], shapeLibrary, Δt_gr)
+end
+
+get_Grad(grad::TrapGradEvent, shapeLibrary, Δt_gr) = Grad(grad.amplitude, grad.flat, grad.rise, grad.fall, grad.delay, 0.0, 0.0)
+
+function get_Grad(grad::ArbGradEvent, shapeLibrary, Δt_gr)
+    amplitude = grad.amplitude
+    first_grads = grad.first
+    last_grads = grad.last
+    amp_shape_id = grad.amp_shape_id
+    time_shape_id = grad.time_shape_id
+    delay = grad.delay
+    #Amplitude
+    gA = amplitude * decompress_shape(shapeLibrary[amp_shape_id]...)
+    n_gr = length(gA) - 1
+    #Creating timings
+    if time_shape_id == 0 #no time waveform. Default time raster
+        gT = n_gr * Δt_gr
+        rise, fall = Δt_gr/2, Δt_gr/2
+    elseif time_shape_id == -1 #New in pulseq 1.5.x: no time waveform. 1/2 of the default time raster
+        gT = n_gr * Δt_gr / 2
+        rise, fall = Δt_gr/2, Δt_gr/2
+    else
+        gt = decompress_shape(shapeLibrary[time_shape_id]...)
+        gt[1] == 0 || @warn "Gradient time shape $time_shape_id starting at a non-zero value $(gt[1]). This is not recommended and may not be supported properly\n (see https://github.com/pulseq/pulseq/issues/188#issuecomment-3541588756) " maxlog=1
+        delay += gt[1] * Δt_gr # offset due to the shape starting at a non-zero value. This case 
+        gT = diff(gt) * Δt_gr
+        rise, fall = 0.0, 0.0
     end
-    return gr
+    gA, gT = simplify_waveforms(gA, gT)
+    return Grad(gA, gT, rise, fall, delay, first_grads, last_grads)
 end
 
 """
-    rf = get_RF(rfLibrary, shapeLibrary, Δt_rf, i)
+    rf, add_half_Δt_rf = get_RF(rfLibrary, shapeLibrary, Δt_rf, i)
 
 Reads the RF. It is used internally by [`get_block`](@ref).
 
 # Arguments
-- `rfLibrary`: (`::Dict{K, V}`) the "rfLibrary" dictionary
-- `shapeLibrary`: (`::Dict{K, V}`) the "shapeLibrary" dictionary
+- `rfLibrary`: (`::Dict{Int, RFEvent}`) the "rfLibrary" dictionary
+- `shapeLibrary`: (`::ShapeLibrary`) the "shapeLibrary" dictionary
 - `Δt_rf`: (`::Float64`, `[s]`) RF raster time
 - `i`: (`::Int64`) index of the RF in the block event
 
 # Returns
-- `rf`: (`1x1 ::Matrix{RF}`) RF struct
+- `rf`: (`::RF`) RF struct
+- `add_half_Δt_rf`: (`::Bool`) whether the block extent needs the trailing half-raster correction
 """
 function get_RF(rfLibrary, shapeLibrary, Δt_rf, i)
     rf = RF(0.0,0.0)
-    haskey(rfLibrary, i) || return [rf;;], false
+    haskey(rfLibrary, i) || return rf, false
     #Unpacking
-    r = rfLibrary[i]["data"]
-    v1_5 = length(r) == 11 # (1)amplitude (2)mag_id (3)phase_id (4)time_shape_id (5)center (6)delay (7)freq_ppm (8)phase_ppm (9)freq (10)phase (11)use
-    v1_4 = length(r) == 7  # (1)amplitude (2)mag_id (3)phase_id (4)time_shape_id (5)delay (6)freq (7)phase
-    v1_3 = length(r) == 6  # (1)amplitude (2)mag_id (3)phase_id (4)delay (5)freq (6)phase
-    amplitude     =  r[1]
-    mag_id        =  r[2] |> x->floor(Int64,x)
-    phase_id      =  r[3] |> x->floor(Int64,x)
-    time_shape_id =  v1_3 ? 0 : (r[4] |> x->floor(Int64,x)); add_half_Δt_rf = !(time_shape_id>0)
-    center        =  v1_5 ? r[5]  : 0.0
-    delay         = (v1_5 ? r[6]  : (v1_4 ? r[5] : r[4])) + (add_half_Δt_rf) * Δt_rf/2
-    freq_ppm      =  v1_5 ? r[7]  : 0.0
-    phase_ppm     =  v1_5 ? r[8]  : 0.0
-    freq          =  v1_5 ? r[9]  : (v1_4 ? r[6] : r[5])
-    phase         =  v1_5 ? r[10] : (v1_4 ? r[7] : r[6])
-    use           =  v1_5 ? r[11] : 'u'
+    r = rfLibrary[i]
+    amplitude = r.amplitude
+    mag_id = r.mag_id
+    phase_id = r.phase_id
+    time_shape_id = r.time_shape_id
+    add_half_Δt_rf = time_shape_id <= 0
+    delay = r.delay + add_half_Δt_rf * Δt_rf / 2
+    freq = r.freq
+    phase = r.phase
     #Amplitude and phase waveforms
     if amplitude != 0 && mag_id != 0
         rfA = decompress_shape(shapeLibrary[mag_id]...)
@@ -704,6 +691,7 @@ function get_RF(rfLibrary, shapeLibrary, Δt_rf, i)
         rfAϕ = amplitude .* rfA .* exp.(1im*(2π*rfϕ .+ phase))
     else
         rfAϕ = ComplexF64[0.0]
+        Nrf = 0
     end
     #Creating timings
     if time_shape_id == 0 #no time waveform. Default time raster
@@ -716,13 +704,12 @@ function get_RF(rfLibrary, shapeLibrary, Δt_rf, i)
         rfT = diff(rft) * Δt_rf
     end
     rfAϕ, rfT = simplify_waveforms(rfAϕ, rfT)
-    use = KomaMRIBase.get_RF_use_from_char(Val(use))
-    if v1_5 # for version 1.5.x
-        rf = RF(rfAϕ,rfT,freq,delay,center,use)
-    else # for version 1.4.x and below
-        rf = RF(rfAϕ,rfT,freq,delay)
+    if isnothing(r.center)
+        rf = RF(rfAϕ, rfT, freq, delay)
+    else
+        rf = RF(rfAϕ, rfT, freq, delay, r.center, KomaMRIBase.get_RF_use_from_char(Val(r.use)))
     end
-    return [rf;;], add_half_Δt_rf
+    return rf, add_half_Δt_rf
 end
 
 """
@@ -731,109 +718,52 @@ end
 Reads the ADC. It is used internally by [`get_block`](@ref).
 
 # Arguments
-- `adcLibrary`: (`::Dict{String, Any}`) the "adcLibrary" dictionary
+- `adcLibrary`: (`::Dict{Int, ADCEvent}`) the "adcLibrary" dictionary
 - `i`: (`::Int64`) index of the adc in the block event
 
 # Returns
-- `adc`: (`1x1 ::Vector{ADC}`) ADC struct
+- `adc`: (`::ADC`) ADC struct
 """
 function get_ADC(adcLibrary, i)
     adc = ADC(0, 0)
-    haskey(adcLibrary, i) || return [adc], 0.0
+    haskey(adcLibrary, i) || return adc
     #Unpacking
-    a = adcLibrary[i]["data"]
-    v1_5 = length(a) == 8 # (1)num (2)dwell (3)delay (4)freq_ppm (5)phase_ppm (6)freq (7)phase (8)phase_shape_id
-    v1_4 = length(a) == 5 # (1)num (2)dwell (3)delay (4)freq (5)phase
-    num       = a[1] |> x->floor(Int64,x)
-    dwell     = a[2]
-    delay     = a[3] + dwell/2
-    freq_ppm  = v1_5 ? a[4] : 0.0
-    phase_ppm = v1_5 ? a[5] : 0.0
-    freq      = v1_5 ? a[6] : a[4]
-    phase     = v1_5 ? a[7] : a[5]
-    phase_id  = v1_5 ? a[8] : 0
+    a = adcLibrary[i]
+    num = a.num
+    dwell = a.dwell
+    delay = a.delay + dwell / 2
+    freq = a.freq
+    phase = a.phase
     #Definition
     T = (num-1) * dwell
-    adc = ADC(num,T,delay,freq,phase)
-    return [adc], delay + T - dwell/2
+    return ADC(num,T,delay,freq,phase)
 end
 
 """
-    seq = get_block(eventIDs, duration, eventLibraries)
+    Gx, Gy, Gz, rf, add_half_Δt_rf, adc, ext = get_block(eventIDs, eventLibraries)
 
-Sequence definition for one block. Used internally by [`fix_first_last_grads`](@ref).
-
-# Arguments
-- `eventIDs`: (`::Vector{Int}`) event IDs for one block
-- `duration`: (`::Float64`) block duration
-- `eventLibraries`: (`::Dict`) main dictionary of event libraries
-
-# Returns
-- `s`: (`::Sequence`) block Sequence struct
-"""
-function get_block(eventIDs, duration, eventLibraries)
-    #Unpacking
-    irf, igx, igy, igz, iadc, iext = eventIDs
-    #Gradient definition
-    Δt_gr = eventLibraries["definitions"]["GradientRasterTime"]
-    Gx = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igx)
-    Gy = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igy)
-    Gz = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igz)
-    G = reshape([Gx;Gy;Gz],3,1) #[Gx;Gy;Gz;;]
-    #RF definition
-    Δt_rf = eventLibraries["definitions"]["RadiofrequencyRasterTime"]
-    R, add_half_Δt_rf = get_RF(eventLibraries["rfLibrary"], eventLibraries["shapeLibrary"], Δt_rf, irf)
-    #ADC definition
-    A, adc_dur = get_ADC(eventLibraries["adcLibrary"], iadc)
-    #DUR
-    max_dur = max(dur(Gx), dur(Gy), dur(Gz), dur(R[1]) + (add_half_Δt_rf) * Δt_rf/2, adc_dur)
-    @assert duration ≈ max_dur || duration >= max_dur "Block duration must be greater than or approximately equal to the duration of the block events"
-    D = Float64[duration]
-    #Extensions
-    E = get_extension(eventLibraries["extensionInstanceLibrary"], eventLibraries["extensionTypeLibrary"], eventLibraries["extensionSpecLibrary"], iext)
-    # Definitition
-    DEF = Dict{String,Any}()
-    #Sequence block definition
-    return Sequence(G,R,A,D,E,DEF)
-end
-
-"""
-    seq = get_block_with_delayID(eventIDs, delayID, eventLibraries)
-
-Sequence definition for one block. For versions < 1.4.0 where the block duration is defined by the delay ID.
+Decode one Pulseq block into gradient, RF, ADC, and extension events.
 
 # Arguments
 - `eventIDs`: (`::Vector{Int}`) event IDs for one block
-- `delayID`: (`::Int`) delay ID
-- `eventLibraries`: (`::Dict`) main dictionary of event libraries
+- `eventLibraries`: (`::PulseqEventLibraries`) main dictionary of event libraries
 
 # Returns
-- `s`: (`::Sequence`) block Sequence struct
+- `Gx`, `Gy`, `Gz`: (`::Grad`) decoded gradient events
+- `rf`: (`::RF`) decoded RF event
+- `add_half_Δt_rf`: (`::Bool`) whether the block extent needs the trailing half-raster correction
+- `adc`: (`::ADC`) decoded ADC event
+- `ext`: (`::Vector{Extension}`) decoded extension events
 """
-function get_block_with_delayID(eventIDs, delayID, eventLibraries)
-    #Unpacking
+function get_block(eventIDs, eventLibraries)
     irf, igx, igy, igz, iadc, iext = eventIDs
-    #Gradient definition
-    Δt_gr = eventLibraries["definitions"]["GradientRasterTime"]
-    Gx = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igx)
-    Gy = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igy)
-    Gz = get_Grad(eventLibraries["gradLibrary"], eventLibraries["shapeLibrary"], Δt_gr, igz)
-    G = reshape([Gx;Gy;Gz],3,1) #[Gx;Gy;Gz;;]
-    #RF definition
-    Δt_rf = eventLibraries["definitions"]["RadiofrequencyRasterTime"]
-    R, add_half_Δt_rf = get_RF(eventLibraries["rfLibrary"], eventLibraries["shapeLibrary"], Δt_rf, irf)
-    #ADC definition
-    A, adc_dur = get_ADC(eventLibraries["adcLibrary"], iadc)
-    #DUR
-    max_dur = max(dur(Gx), dur(Gy), dur(Gz), dur(R[1]) + (add_half_Δt_rf) * Δt_rf/2, adc_dur)
-    delay = delayID > 0 ? eventLibraries["tmp_delayLibrary"][delayID]["data"][1] : 0.0
-    D = Float64[max(delay, max_dur)]
-    #Extensions
-    E = get_extension(eventLibraries["extensionInstanceLibrary"], eventLibraries["extensionTypeLibrary"], eventLibraries["extensionSpecLibrary"], iext)
-    # Definitition
-    DEF = Dict{String,Any}()
-    #Sequence block definition
-    return Sequence(G,R,A,D,E,DEF)
+    Gx = get_Grad(eventLibraries.grad_library, eventLibraries.shape_library, eventLibraries.gradient_raster_time, igx)
+    Gy = get_Grad(eventLibraries.grad_library, eventLibraries.shape_library, eventLibraries.gradient_raster_time, igy)
+    Gz = get_Grad(eventLibraries.grad_library, eventLibraries.shape_library, eventLibraries.gradient_raster_time, igz)
+    rf, add_half_Δt_rf = get_RF(eventLibraries.rf_library, eventLibraries.shape_library, eventLibraries.radiofrequency_raster_time, irf)
+    adc = get_ADC(eventLibraries.adc_library, iadc)
+    ext = get_extension(eventLibraries.extension_instance_library, eventLibraries.extension_type_library, eventLibraries.extension_spec_library, iext)
+    return Gx, Gy, Gz, rf, add_half_Δt_rf, adc, ext
 end
 
 """
@@ -854,21 +784,19 @@ Reads the extension(s) for a block event in a Pulseq sequence file.
 The available extensions are currently contained in the file KomaMRIBase/src/datatypes/sequence/EXT.jl
 """
 function get_extension(extensionInstanceLibrary, extensionTypeLibrary, extensionSpecLibrary, i)
-    EXT = [Extension[]]
+    EXT = Extension[]
     haskey(extensionInstanceLibrary, i) || return EXT
     # type ref next_id
     # next_id of 0 terminates the list
-    type, ref, next_id = extensionInstanceLibrary[i]["data"]
-    while true
-        if haskey(extensionTypeLibrary, type) push!(EXT[1], extensionTypeLibrary[type](extensionSpecLibrary[type][ref]["data"]...)) end
-        if next_id == 0
-            break
-        else
-            type, ref, next_id = extensionInstanceLibrary[next_id]["data"]
+    while i != 0
+        entry = extensionInstanceLibrary[i]
+        if haskey(extensionTypeLibrary, entry.type)
+            push!(EXT, extensionTypeLibrary[entry.type](extensionSpecLibrary[entry.type][entry.ref]...))
         end
+        i = entry.next_id
     end
     return EXT
- end
+end
 
 # ----------------- Signature-related functions ------------------
 function supported_signature_digest(algorithm::AbstractString, payload::Vector{UInt8})

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -577,7 +577,7 @@ function read_seq(filename)
         # initialize blockDurations
         resize!(blockDurations, size(blockEvents, 2))
         # inefficient but convenient way to get the block durations for older versions
-        for i = 1:size(blockEvents, 1)
+        for i = 1:size(blockEvents, 2)
             block = get_block_with_delayID(blockEvents[:, i], delayIDs_tmp[i], eventLibraries)
             blockDurations[i] = dur(block)
         end

--- a/KomaMRIFiles/src/Sequence/Pulseq.jl
+++ b/KomaMRIFiles/src/Sequence/Pulseq.jl
@@ -87,11 +87,9 @@ read_blocks Read the [BLOCKS] section of a sequence file.
 """
 function read_blocks(io, pulseq_version)
     NumberBlockEvents = pulseq_version <= v"1.2.1" ? 7 : 8
-    # we'll collect everything into a vector and then reshape later
-    # we assume that we have at least 1000 blocks and pre-allocate for that
-    blocks = empty!(Vector{Int}(undef, NumberBlockEvents * 1000))
-    blockDurations = empty!(Vector{Float64}(undef, 1000))
-    delayIDs_tmp = empty!(Vector{Int}(undef, 1000))
+    blocks = Int[]
+    blockDurations = Float64[]
+    delayIDs_tmp = Int[]
     num_lines = 0
     while true
         blockEvents = [parse(Int, d) for d in eachsplit(readline(io))]
@@ -417,12 +415,12 @@ function get_seq_from_blocks(blockEvents::Array{Int, 2}, blockDurations::Vector{
 
     # RF events
     Δt_rf = eventLibraries["definitions"]["RadiofrequencyRasterTime"]
-    RFs = empty!(Vector{RF}(undef, num_blocks))
+    RFs = RF[]
     append!(RFs, get_RF(eventLibraries["rfLibrary"], eventLibraries["shapeLibrary"], Δt_rf, id)[1][1, 1] for id in ids_rf)
     RFs = reshape(RFs, 1, num_blocks)
 
     # ADC events
-    ADCs = empty!(Vector{ADC}(undef, num_blocks))
+    ADCs = ADC[]
     append!(ADCs, (get_ADC(eventLibraries["adcLibrary"], id)[1][1] for id in ids_adc))
 
     # Extensions
@@ -465,7 +463,7 @@ function read_seq(filename)
     def = Dict()
     signature = nothing
     blockEvents = Array{Int, 2}(undef, 0, 0)
-    blockDurations_rasterUnits = Vector{Int}(undef, 0)
+    blockDurations_rasterUnits = Vector{Int}(undef, 0) 
     delayIDs_tmp = Vector{Int}(undef, 0)
     rfLibrary = Dict()
     adcLibrary = Dict()
@@ -575,10 +573,10 @@ function read_seq(filename)
     )
 
     if pulseq_version < v"1.4.0"
-        # initialize blockDurations
-        resize!(blockDurations, size(blockEvents, 2))
         # inefficient but convenient way to get the block durations for older versions
-        for i = 1:size(blockEvents, 2)
+        num_blocks = size(blockEvents, 2)
+        blockDurations = Vector{Float64}(undef, num_blocks)
+        for i = 1:num_blocks
             block = get_block_with_delayID(blockEvents[:, i], delayIDs_tmp[i], eventLibraries)
             blockDurations[i] = dur(block)
         end

--- a/KomaMRIFiles/src/Sequence/PulseqEvents.jl
+++ b/KomaMRIFiles/src/Sequence/PulseqEvents.jl
@@ -1,0 +1,109 @@
+struct TrapGradEvent
+    amplitude::Float64
+    rise::Float64
+    flat::Float64
+    fall::Float64
+    delay::Float64
+end
+
+mutable struct ArbGradEvent
+    amplitude::Float64
+    first::Float64
+    last::Float64
+    amp_shape_id::Int
+    time_shape_id::Int
+    delay::Float64
+end
+
+struct RFEvent
+    amplitude::Float64
+    mag_id::Int
+    phase_id::Int
+    time_shape_id::Int
+    center::Union{Nothing, Float64}
+    delay::Float64
+    freq_ppm::Float64
+    phase_ppm::Float64
+    freq::Float64
+    phase::Float64
+    use::Char
+end
+
+struct ADCEvent
+    num::Int
+    dwell::Float64
+    delay::Float64
+    freq_ppm::Float64
+    phase_ppm::Float64
+    freq::Float64
+    phase::Float64
+    phase_id::Int
+end
+
+struct ExtensionInstanceEvent
+    type::Int
+    ref::Int
+    next_id::Int
+end
+
+const GradEvent = Union{TrapGradEvent, ArbGradEvent}
+const ShapeLibrary = Dict{Int, Tuple{Int, Vector{Float64}}}
+
+struct PulseqEventLibraries
+    grad_library::Dict{Int, GradEvent}
+    rf_library::Dict{Int, RFEvent}
+    adc_library::Dict{Int, ADCEvent}
+    tmp_delay_library::Dict{Int, Float64}
+    shape_library::ShapeLibrary
+    extension_instance_library::Dict{Int, ExtensionInstanceEvent}
+    extension_type_library::Dict{Int, Type{<:Extension}}
+    extension_spec_library::Dict{Int, Dict{Int, Tuple}}
+    definitions::Dict{String, Any}
+    block_duration_raster::Float64
+    gradient_raster_time::Float64
+    radiofrequency_raster_time::Float64
+    adc_raster_time::Float64
+end
+
+function PulseqEventLibraries(
+    grad_library,
+    rf_library,
+    adc_library,
+    tmp_delay_library,
+    shape_library,
+    extension_instance_library,
+    extension_type_library,
+    extension_spec_library,
+    definitions,
+)
+    defs = Dict{String, Any}(definitions)
+    return PulseqEventLibraries(
+        grad_library,
+        rf_library,
+        adc_library,
+        tmp_delay_library,
+        shape_library,
+        extension_instance_library,
+        extension_type_library,
+        extension_spec_library,
+        defs,
+        defs["BlockDurationRaster"],
+        defs["GradientRasterTime"],
+        defs["RadiofrequencyRasterTime"],
+        defs["AdcRasterTime"],
+    )
+end
+
+TrapGradEvent(data) = TrapGradEvent(data...)
+ArbGradEvent(data::NTuple{3, T}) where {T<:Real} = ArbGradEvent(data[1], 0.0, 0.0, Int(data[2]), 0, data[3])
+ArbGradEvent(data::NTuple{4, T}) where {T<:Real} = ArbGradEvent(data[1], 0.0, 0.0, Int(data[2]), Int(data[3]), data[4])
+ArbGradEvent(data::NTuple{6, T}) where {T<:Real} = ArbGradEvent(data[1], data[2], data[3], Int(data[4]), Int(data[5]), data[6])
+
+RFEvent(data::NTuple{6, T}) where {T<:Real} = RFEvent(data[1], Int(data[2]), Int(data[3]), 0, nothing, data[4], 0.0, 0.0, data[5], data[6], 'u')
+RFEvent(data::NTuple{7, T}) where {T<:Real} = RFEvent(data[1], Int(data[2]), Int(data[3]), Int(data[4]), nothing, data[5], 0.0, 0.0, data[6], data[7], 'u')
+RFEvent(data::Tuple{Vararg{Any, 11}}) = RFEvent(data[1], Int(data[2]), Int(data[3]), Int(data[4]), data[5], data[6], data[7], data[8], data[9], data[10], data[11])
+
+ADCEvent(data::NTuple{5, T}) where {T<:Real} = ADCEvent(Int(data[1]), data[2], data[3], 0.0, 0.0, data[4], data[5], 0)
+ADCEvent(data::NTuple{8, T}) where {T<:Real} = ADCEvent(Int(data[1]), data[2], data[3], data[4], data[5], data[6], data[7], Int(data[8]))
+
+ExtensionInstanceEvent(data) = ExtensionInstanceEvent(Int(data[1]), Int(data[2]), Int(data[3]))


### PR DESCRIPTION
Sequence blocks are stored in an array instead of a dictionary for I/O efficiency, addressing [1]. Blocks are ordered sequentially in the array (and thus block IDs are ignored) as discussed in [2]. Solution is adapted from an older draft solution from @gabuzi  [3].

[1] https://github.com/JuliaHealth/KomaMRI.jl/issues/224
[2] https://github.com/pulseq/pulseq/issues/40
[3] https://github.com/JuliaHealth/KomaMRI.jl/pull/238/changes

In the below example I find a 50x speedup in reading tse.seq, a 9MB pulseq file implementing multi-slab 3DTSE. This speedup factor tends to increase with the sequence length / file size.

Before change:
<img width="1215" height="105" alt="readseq-time-before" src="https://github.com/user-attachments/assets/190e9318-4f25-4c75-8d19-463098ca94f6" />
After change:
<img width="1180" height="108" alt="readseq-time-after" src="https://github.com/user-attachments/assets/157e28a5-4f2d-4f8e-a0f6-f88c65ac73d9" />

