### PR TITLE
Disable oneAPI CI and benchmark publishing by default

### DIFF
--- a/.buildkite/runbenchmarks.yml
+++ b/.buildkite/runbenchmarks.yml
@@ -117,32 +117,34 @@ steps:
           BENCHMARK_GROUP: Metal
         timeout_in_minutes: 30
 
-      - label: "oneAPI: Run Benchmarks"
-        plugins:
-          - JuliaCI/julia#v1:
-              version: "1"
-        command: |
-          julia --project=benchmarks -e 'println("--- :julia: Instantiating project")
-              using Pkg
-              Pkg.develop([
-                  PackageSpec(path=pwd(), subdir="KomaMRIBase"),
-                  PackageSpec(path=pwd(), subdir="KomaMRICore"),
-              ])'
-
-          julia --project=benchmarks -e 'println("---:julia: Add CUDA to benchmarks environment")
-              using Pkg
-              Pkg.add("oneAPI")'
-          
-          julia --project=benchmarks -e 'println("--- :julia: Run Benchmarks")
-              include("benchmarks/runbenchmarks.jl")'
-        artifact_paths: 
-          - "benchmarks/results/*"
-        agents:
-          queue: "juliagpu"
-          intel: "*"
-        env:
-          BENCHMARK_GROUP: oneAPI
-        timeout_in_minutes: 30
+      # oneAPI benchmark uploads are intentionally disabled for now because the
+      # backend is too flaky in CI. Historical oneAPI data remains on gh-pages.
+      # - label: "oneAPI: Run Benchmarks"
+      #   plugins:
+      #     - JuliaCI/julia#v1:
+      #         version: "1"
+      #   command: |
+      #     julia --project=benchmarks -e 'println("--- :julia: Instantiating project")
+      #         using Pkg
+      #         Pkg.develop([
+      #             PackageSpec(path=pwd(), subdir="KomaMRIBase"),
+      #             PackageSpec(path=pwd(), subdir="KomaMRICore"),
+      #         ])'
+      #
+      #     julia --project=benchmarks -e 'println("---:julia: Add oneAPI to benchmarks environment")
+      #         using Pkg
+      #         Pkg.add("oneAPI")'
+      #
+      #     julia --project=benchmarks -e 'println("--- :julia: Run Benchmarks")
+      #         include("benchmarks/runbenchmarks.jl")'
+      #   artifact_paths:
+      #     - "benchmarks/results/*"
+      #   agents:
+      #     queue: "juliagpu"
+      #     intel: "*"
+      #   env:
+      #     BENCHMARK_GROUP: oneAPI
+      #   timeout_in_minutes: 30
 
       - wait: ~
 

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -155,49 +155,51 @@ steps:
           arch: "aarch64"
         timeout_in_minutes: 60
 
-      - label: "oneAPI: Run tests on v{{matrix.version}}"
-        matrix:
-          setup:
-            version:
-              - "1.10"
-              - "1"
-        plugins:
-          - JuliaCI/julia#v1:
-              version: "{{matrix.version}}"
-          - JuliaCI/julia-coverage:
-              codecov: true
-              flags:
-                - core
-              dirs:
-                - KomaMRICore/src
-                - KomaMRICore/ext
-        env:
-          TEST_GROUP: $TEST_GROUP
-        command: |
-          julia -e 'println("--- :julia: Instantiating project")
-              using Pkg
-              if !( VERSION < v"1.11" )
-                  Pkg.activate("KomaMRICore/test")
-              end
-              Pkg.develop([
-                  PackageSpec(path=pwd(), subdir="KomaMRIBase"),
-                  PackageSpec(path=pwd(), subdir="KomaMRICore"),
-              ])'
-          
-          julia --project=KomaMRICore/test -e 'println("--- :julia: Add oneAPI to test environment")
-              using Pkg
-              Pkg.add("oneAPI")'
-
-          julia -e 'println("--- :julia: Running tests")
-              using Pkg
-              if !( VERSION < v"1.11" )
-                  Pkg.activate("KomaMRICore/test")
-              end
-              Pkg.test("KomaMRICore"; coverage=true, test_args=["oneAPI"])'
-        agents:
-          queue: "juliagpu"
-          intel: "*"
-        timeout_in_minutes: 60
+      # oneAPI CI is intentionally disabled for now because the backend is too
+      # flaky in Buildkite. Keep the step here so it can be re-enabled later.
+      # - label: "oneAPI: Run tests on v{{matrix.version}}"
+      #   matrix:
+      #     setup:
+      #       version:
+      #         - "1.10"
+      #         - "1"
+      #   plugins:
+      #     - JuliaCI/julia#v1:
+      #         version: "{{matrix.version}}"
+      #     - JuliaCI/julia-coverage:
+      #         codecov: true
+      #         flags:
+      #           - core
+      #         dirs:
+      #           - KomaMRICore/src
+      #           - KomaMRICore/ext
+      #   env:
+      #     TEST_GROUP: $TEST_GROUP
+      #   command: |
+      #     julia -e 'println("--- :julia: Instantiating project")
+      #         using Pkg
+      #         if !( VERSION < v"1.11" )
+      #             Pkg.activate("KomaMRICore/test")
+      #         end
+      #         Pkg.develop([
+      #             PackageSpec(path=pwd(), subdir="KomaMRIBase"),
+      #             PackageSpec(path=pwd(), subdir="KomaMRICore"),
+      #         ])'
+      #
+      #     julia --project=KomaMRICore/test -e 'println("--- :julia: Add oneAPI to test environment")
+      #         using Pkg
+      #         Pkg.add("oneAPI")'
+      #
+      #     julia -e 'println("--- :julia: Running tests")
+      #         using Pkg
+      #         if !( VERSION < v"1.11" )
+      #             Pkg.activate("KomaMRICore/test")
+      #         end
+      #         Pkg.test("KomaMRICore"; coverage=true, test_args=["oneAPI"])'
+      #   agents:
+      #     queue: "juliagpu"
+      #     intel: "*"
+      #   timeout_in_minutes: 60
 
 env:
   CI: BUILDKITE

--- a/KomaMRICore/ext/KomaoneAPIExt.jl
+++ b/KomaMRICore/ext/KomaoneAPIExt.jl
@@ -58,7 +58,7 @@ end
 
 function __init__()
     push!(KomaMRICore.LOADED_BACKENDS[], oneAPIBackend())
-    @warn "oneAPI does not support all array operations used by KomaMRI. GPU performance may be slower than expected"
+    @warn "oneAPI support is experimental and does not support all array operations used by KomaMRI. GPU performance may be slower than expected"
 end
 
 end

--- a/KomaMRICore/src/simulation/Functors.jl
+++ b/KomaMRICore/src/simulation/Functors.jl
@@ -10,7 +10,8 @@ _isleaf(::AbstractRange) = true
     gpu(x)
 
 Moves 'x' to the GPU. For this function to work, a GPU backend will need to be
-loaded with 'using AMDGPU / CUDA / Metal / oneAPI.
+loaded with 'using AMDGPU / CUDA / Metal / oneAPI'. oneAPI support is
+experimental.
 
 This works for functions, and any struct marked with `@functor`.
 
@@ -30,7 +31,7 @@ function gpu(x)
     if (BACKEND[] isa KA.GPU)
         return gpu(x, BACKEND[])
     else
-        @warn "function 'gpu' called with no functional backends available. Add 'using CUDA / Metal / AMDGPU / oneAPI' to your code and try again"
+        @warn "function 'gpu' called with no functional backends available. Add 'using CUDA / Metal / AMDGPU / oneAPI' to your code and try again. oneAPI support is experimental"
         return x
     end
 end

--- a/KomaMRICore/src/simulation/GPUFunctions.jl
+++ b/KomaMRICore/src/simulation/GPUFunctions.jl
@@ -25,10 +25,11 @@ const u32 = Literal(UInt32)
 
 Gets the simulation backend to use. If use_gpu=false or there are no available GPU backends, 
 returns CPU(), else, returns the GPU backend (currently either CUDABackend(), MetalBackend(), 
-ROCBackend(), or oneAPIBackend()).
+ROCBackend(), or oneAPIBackend() (experimental).
 
-The GPU package for the corresponding backend (CUDA.jl, Metal.jl, AMDGPU.jl, or oneAPI.jl) must be
-loaded and functional, otherwise KomaMRI will default to using the CPU.
+The GPU package for the corresponding backend (CUDA.jl, Metal.jl, AMDGPU.jl, or
+oneAPI.jl) must be loaded and functional, otherwise KomaMRI will default to using
+the CPU. oneAPI support is experimental.
 
 # Arguments
 - 'use_gpu': ('::Bool') If true, attempt to use GPU and check for available backends
@@ -53,7 +54,7 @@ function get_backend(use_gpu::Bool)
           The GPU functionality is being called but no GPU backend is loaded 
           to access it. Add 'using CUDA / Metal / AMDGPU / oneAPI' to your 
           code. Defaulting back to the CPU. (No action is required if you want
-          to run on the CPU).
+          to run on the CPU). oneAPI support is experimental.
         """ maxlog=1
         BACKEND[] = KA.CPU()
         return BACKEND[]

--- a/KomaMRICore/test/initialize_backend.jl
+++ b/KomaMRICore/test/initialize_backend.jl
@@ -12,7 +12,7 @@ end
 # For testing with CUDA:   ] add CUDA   to KomaMRICore/test/Project.toml
 # For testing with AMDGPU: ] add AMDGPU to KomaMRICore/test/Project.toml
 # For testing with Metal:  ] add Metal  to KomaMRICore/test/Project.toml
-# For testing with oneAPI: ] add oneAPI to KomaMRICore/test/Project.toml
+# For testing with oneAPI (experimental): ] add oneAPI to KomaMRICore/test/Project.toml
 USE_GPU = any(AVAILABLE_GPU_BACKENDS .∈ Ref(TEST_BACKENDS))
 if "CUDA" in TEST_BACKENDS
     using CUDA

--- a/KomaMRICore/test/runtests.jl
+++ b/KomaMRICore/test/runtests.jl
@@ -2,8 +2,9 @@ using TestItems, TestItemRunner
 
 ### NOTE: by default, tests are run on the CPU with the number of threads set to
 #   Threads.nthreads(). To run on a specific GPU backend, add the name of the
-#   backend package ("AMDGPU", "CUDA", "Metal", or "oneAPI") to the test/Project.toml
-#   file in KomaMRICore and pass the name as a test argument.
+#   backend package ("AMDGPU", "CUDA", "Metal", or "oneAPI") to the
+#   test/Project.toml file in KomaMRICore and pass the name as a test argument.
+#   oneAPI is experimental.
 #
 #   Example:
 #

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To install, just **type** `] add KomaMRI` in the Julia REPL or copy-paste the fo
 
 ```julia
 pkg> add KomaMRI
-pkg> add CUDA     # Optional: Install desired GPU backend (CUDA, AMDGPU, Metal, or oneAPI)
+pkg> add CUDA     # Optional: Install desired GPU backend (CUDA, AMDGPU, Metal, or oneAPI (experimental))
 
 ```
 For more information about installation instructions, refer to the section [Getting Started](https://JuliaHealth.github.io/KomaMRI.jl/dev/how-to/1-getting-started) of the documentation.
@@ -120,7 +120,7 @@ KomaUI()
 Press the button that says "Simulate!" to do your first simulation :). Then, a notification will emerge telling you that the simulation was successful. In this notification, you can either select to (1) see the Raw Data or (2) to proceed with the reconstruction.
 
 > [!IMPORTANT]
-> Starting from **KomaMRI v0.9** we are using [package extensions](https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)) to deal with GPU dependencies, meaning that to run simulations on the GPU, installing (`add CUDA/AMDGPU/Metal/oneAPI`) and loading (`using CUDA/AMDGPU/Metal/oneAPI`) the desired backend will be necessary (see [GPU Parallelization](https://JuliaHealth.github.io/KomaMRI.jl/dev/explanation/7-gpu-explanation) and [Tested compatibility](#tested-compatibility)).  
+> Starting from **KomaMRI v0.9** we are using [package extensions](https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)) to deal with GPU dependencies, meaning that to run simulations on the GPU, installing (`add CUDA/AMDGPU/Metal/oneAPI`) and loading (`using CUDA/AMDGPU/Metal/oneAPI`) the desired backend will be necessary. Note that oneAPI support is experimental (see [GPU Parallelization](https://JuliaHealth.github.io/KomaMRI.jl/dev/explanation/7-gpu-explanation) and [Tested compatibility](#tested-compatibility)).
 
 ## How to Contribute
 KomaMRI exists thanks to all our contributors:
@@ -157,14 +157,14 @@ If you use this package, please cite our paper.
 
 ## Tested compatibility
 
-All parallel backends are tested on Linux (besides Apple silicon) using the latest stable release, Julia 1 (stable), and Julia 1.9 (compat). 
+CUDA, AMDGPU, and Metal are tested on Linux (besides Apple silicon) using the latest stable release, Julia 1 (stable), and Julia 1.10 (compat). oneAPI support is experimental and is not included in the status badges below.
 
 <div align="center">
 
-| KomaMRICore          | CPU                                 | GPU (Nvidia)                        | GPU (AMD)                        | GPU (Apple)                        | GPU (Intel)                        | 
-|:---------------------|:-----------------------------------:|:-----------------------------------:|:--------------------------------:|:----------------------------------:|:----------------------------------:|
-| Julia 1.10           | [![][cpu-compat]][buildkite-url]    | [![][nvidia-compat]][buildkite-url] | [![][amd-compat]][buildkite-url] | [![][apple-compat]][buildkite-url] | [![][intel-compat]][buildkite-url] |
-| Julia 1              | [![][cpu-stable]][buildkite-url]    | [![][nvidia-stable]][buildkite-url] | [![][amd-stable]][buildkite-url] | [![][apple-stable]][buildkite-url] | [![][intel-stable]][buildkite-url] |
+| KomaMRICore          | CPU                                 | GPU (Nvidia)                        | GPU (AMD)                        | GPU (Apple)                        |
+|:---------------------|:-----------------------------------:|:-----------------------------------:|:--------------------------------:|:----------------------------------:|
+| Julia 1.10           | [![][cpu-compat]][buildkite-url]    | [![][nvidia-compat]][buildkite-url] | [![][amd-compat]][buildkite-url] | [![][apple-compat]][buildkite-url] |
+| Julia 1              | [![][cpu-stable]][buildkite-url]    | [![][nvidia-stable]][buildkite-url] | [![][amd-stable]][buildkite-url] | [![][apple-stable]][buildkite-url] |
 
 </div>
 
@@ -211,13 +211,10 @@ If you see any problem with this information, please let us know in a GitHub iss
 [nvidia-stable]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=CUDA%3A%20Run%20tests%20on%20v1
 [amd-stable]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=AMDGPU%3A%20Run%20tests%20on%20v1
 [apple-stable]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=Metal%3A%20Run%20tests%20on%20v1
-[intel-stable]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=oneAPI%3A%20Run%20tests%20on%20v1
-
 [cpu-compat]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=CPU%3A%20Run%20tests%20on%20v1.10
 [nvidia-compat]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=CUDA%3A%20Run%20tests%20on%20v1.10
 [amd-compat]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=AMDGPU%3A%20Run%20tests%20on%20v1.10
 [apple-compat]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=Metal%3A%20Run%20tests%20on%20v1.10
-[intel-compat]: https://badge.buildkite.com/f3c2e589ac0c1310cda3c2092814e33ac9db15b4f103eb572b.svg?branch=master&step=oneAPI%3A%20Run%20tests%20on%20v1.10
 
 [buildkite-url]: https://buildkite.com/julialang/komamri-dot-jl/builds
 <!-- CI -->

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ KomaUI()
 Press the button that says "Simulate!" to do your first simulation :). Then, a notification will emerge telling you that the simulation was successful. In this notification, you can either select to (1) see the Raw Data or (2) to proceed with the reconstruction.
 
 > [!IMPORTANT]
-> Starting from **KomaMRI v0.9** we are using [package extensions](https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)) to deal with GPU dependencies, meaning that to run simulations on the GPU, installing (`add CUDA/AMDGPU/Metal/oneAPI`) and loading (`using CUDA/AMDGPU/Metal/oneAPI`) the desired backend will be necessary. Note that oneAPI support is experimental (see [GPU Parallelization](https://JuliaHealth.github.io/KomaMRI.jl/dev/explanation/7-gpu-explanation) and [Tested compatibility](#tested-compatibility)).
+> Starting from **KomaMRI v0.9** we are using [package extensions](https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)) to deal with GPU dependencies, meaning that to run simulations on the GPU, installing (`add CUDA/AMDGPU/Metal/oneAPI (experimental)`) and loading (`using CUDA/AMDGPU/Metal/oneAPI`) the desired backend will be necessary (see [GPU Parallelization](https://JuliaHealth.github.io/KomaMRI.jl/dev/explanation/7-gpu-explanation) and [Tested compatibility](#tested-compatibility)).
 
 ## How to Contribute
 KomaMRI exists thanks to all our contributors:

--- a/benchmarks/aggregate.jl
+++ b/benchmarks/aggregate.jl
@@ -1,6 +1,15 @@
 using BenchmarkTools
 
-const GPU_BACKENDS = ["AMDGPU", "CUDA", "Metal", "oneAPI"]
+const DEFAULT_GPU_BACKENDS = ["AMDGPU", "CUDA", "Metal"]
+const EXPERIMENTAL_GPU_BACKENDS = ["oneAPI"]
+# Keep experimental backends out of published benchmark data by default while
+# still allowing manual opt-in aggregation when needed.
+const INCLUDE_EXPERIMENTAL_GPU_BACKENDS = get(
+    ENV, "INCLUDE_EXPERIMENTAL_GPU_BACKENDS", "false"
+) == "true"
+const GPU_BACKENDS = INCLUDE_EXPERIMENTAL_GPU_BACKENDS ?
+    [DEFAULT_GPU_BACKENDS; EXPERIMENTAL_GPU_BACKENDS] :
+    DEFAULT_GPU_BACKENDS
 const NUM_CPU_THREADS = [1, 2, 4, 8]
 
 #Start with CPU benchmarks for 1 thread and add other results

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -9,7 +9,8 @@ BenchmarkTools.DEFAULT_PARAMETERS.gcsample = true
 BenchmarkTools.DEFAULT_PARAMETERS.seconds = 120
 
 # To run benchmarks on a specific GPU backend, add AMDGPU / CUDA / Metal / oneAPI
-# to benchmarks/Project.toml and change BENCHMARK_GROUP to the backend name
+# to benchmarks/Project.toml and change BENCHMARK_GROUP to the backend name.
+# oneAPI support is experimental and is disabled in CI benchmark publishing.
 const BENCHMARK_GROUP = get(ENV, "BENCHMARK_GROUP", "CPU")
 const BENCHMARK_CPU_THREADS = Threads.nthreads()
 
@@ -29,7 +30,7 @@ elseif BENCHMARK_GROUP == "Metal"
     @info "Running Metal benchmarks" maxlog=1
 elseif BENCHMARK_GROUP == "oneAPI"
     using oneAPI # ] add oneAPI to benchmarks/Project.toml
-    @info "Running oneAPI benchmarks" maxlog=1
+    @info "Running oneAPI benchmarks (experimental)" maxlog=1
 else
     @info "Running CPU benchmarks with $(BENCHMARK_CPU_THREADS) thread(s)" maxlog=1
 end

--- a/docs/src/explanation/7-gpu-explanation.md
+++ b/docs/src/explanation/7-gpu-explanation.md
@@ -5,7 +5,7 @@ KomaMRI uses a vendor agnostic approach to GPU parallelization in order to suppo
 * CUDA.jl (Nvidia)
 * Metal.jl (Apple)
 * AMDGPU.jl (AMD)
-* oneAPI.jl (Intel, experimental)
+* oneAPI.jl (Intel, experimental: not tested or benchmarked)
 
 ## Choosing a GPU Backend
 

--- a/docs/src/explanation/7-gpu-explanation.md
+++ b/docs/src/explanation/7-gpu-explanation.md
@@ -5,7 +5,7 @@ KomaMRI uses a vendor agnostic approach to GPU parallelization in order to suppo
 * CUDA.jl (Nvidia)
 * Metal.jl (Apple)
 * AMDGPU.jl (AMD)
-* oneAPI.jl (Intel)
+* oneAPI.jl (Intel, experimental)
 
 ## Choosing a GPU Backend
 

--- a/docs/src/how-to/5-contribute-to-koma.md
+++ b/docs/src/how-to/5-contribute-to-koma.md
@@ -178,13 +178,13 @@ To change the default backend used for testing, modify the `[preferences.KomaMRI
 [preferences.KomaMRICore]
 test_backend = "CPU"
 ```
-The variable `test_backend` can be changed to “CPU”, “CUDA”, “AMDGPU”, “Metal”, or “oneAPI”. After this change, **restart VSCode**. Make sure that the required backend is installed in Julia’s global environment before testing. This is, for example, `@v1.10` for Julia 1.10.
+The variable `test_backend` can be changed to “CPU”, “CUDA”, “AMDGPU”, “Metal”, or “oneAPI” (experimental). After this change, **restart VSCode**. Make sure that the required backend is installed in Julia’s global environment before testing. This is, for example, `@v1.10` for Julia 1.10.
 
 **Test With Julia REPL:**
 
 By default, tests are run on the CPU with the number of threads set to `Threads.nthreads()`. To choose a specific backend, two methods exist: 
 
-**Method 1 - Using Preferences:** Add the name of the backend ("CPU","CUDA","AMDGPU","Metal", or "oneAPI") to the `test/Project.toml` file in `KomaMRICore`. Then, test as usual:
+**Method 1 - Using Preferences:** Add the name of the backend ("CPU","CUDA","AMDGPU","Metal", or "oneAPI") to the `test/Project.toml` file in `KomaMRICore`. oneAPI is experimental. Then, test as usual:
 
 ```julia-repl
 pkg> test KomaMRICore
@@ -264,6 +264,6 @@ To finish your pull request, give it a name with a clear mention of the subject 
 
 ### (Advanced) GPU CI Testing
 
-KomaMRI runs continuous integration tests on multiple GPU backends (CUDA, AMDGPU, Metal, oneAPI) via Buildkite. To control resource usage and costs, **GPU tests are not run by default** on pull requests.
+KomaMRI runs continuous integration tests on multiple GPU backends (CUDA, AMDGPU, and Metal) via Buildkite. To control resource usage and costs, **GPU tests are not run by default** on pull requests. oneAPI support is experimental and is currently excluded from default CI and benchmark runs.
 
 If your contribution affects GPU code, such as files in `KomaMRICore/ext/` or simulation kernels, please request `@cncastillo` to add the `run-gpu-ci` label to your PR.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,7 @@ features:
 
   - icon: 🚀
     title: Fast, Device Agnostic
-    details: Run on CPU and GPU with CUDA, AMDGPU, Metal, and oneAPI support. Differentiable simulations powered by Enzyme and Reactant.
+    details: Run on CPU and GPU with CUDA, AMDGPU, Metal, and experimental oneAPI support. Differentiable simulations powered by Enzyme and Reactant.
     link: /explanation/6-simulation
 
   - icon: 🌊
@@ -62,7 +62,7 @@ julia> import Pkg; Pkg.add("KomaMRI")
 
 ## GPU Support
 
-KomaMRI supports GPU acceleration with CUDA, AMDGPU, Metal, and oneAPI. To use GPU acceleration, install the corresponding backend package:
+KomaMRI supports GPU acceleration with CUDA, AMDGPU, Metal, and experimental oneAPI support. To use GPU acceleration, install the corresponding backend package:
 
 :::code-group
 
@@ -87,7 +87,7 @@ import Pkg; Pkg.add("Metal")
 using KomaMRI, Metal
 ```
 
-```julia [Intel GPUs]
+```julia [Intel GPUs (experimental)]
 # Install
 import Pkg; Pkg.add("oneAPI")
 # Load


### PR DESCRIPTION
## Summary
- remove oneAPI status badges and clarify that oneAPI support is experimental in the user-facing docs
- comment out the oneAPI Buildkite test and benchmark steps
- keep benchmark publishing working by excluding experimental backends from aggregation by default while preserving an opt-in path for manual aggregation

## Validation
-  on CPU passed locally
- benchmark aggregation check passed with a synthetic : default aggregation omits oneAPI, and  restores it