### PR TITLE
Fix oneAPI Buildkite integration

### DIFF
--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -156,8 +156,7 @@ steps:
           arch: "aarch64"
         timeout_in_minutes: 60
 
-      - label: "oneAPI - Julia {{matrix.version}} - Test - Core"
-        if: build.env("TEST_GROUP") == "nomotion"
+      - label: "oneAPI - Julia {{matrix.version}} - Test"
         matrix:
           setup:
             version:
@@ -174,7 +173,7 @@ steps:
                 - KomaMRICore/src
                 - KomaMRICore/ext
         env:
-          TEST_GROUP: "core"
+          TEST_GROUP: $TEST_GROUP
         command: |
           julia -e 'println("--- :julia: Instantiating project")
               using Pkg

--- a/benchmarks/aggregate.jl
+++ b/benchmarks/aggregate.jl
@@ -1,15 +1,6 @@
 using BenchmarkTools
 
-const DEFAULT_GPU_BACKENDS = ["AMDGPU", "CUDA", "Metal"]
-const EXPERIMENTAL_GPU_BACKENDS = ["oneAPI"]
-# Keep experimental backends out of published benchmark data by default while
-# still allowing manual opt-in aggregation when needed.
-const INCLUDE_EXPERIMENTAL_GPU_BACKENDS = get(
-    ENV, "INCLUDE_EXPERIMENTAL_GPU_BACKENDS", "false"
-) == "true"
-const GPU_BACKENDS = INCLUDE_EXPERIMENTAL_GPU_BACKENDS ?
-    [DEFAULT_GPU_BACKENDS; EXPERIMENTAL_GPU_BACKENDS] :
-    DEFAULT_GPU_BACKENDS
+const GPU_BACKENDS = ["AMDGPU", "CUDA", "Metal", "oneAPI"]
 const NUM_CPU_THREADS = [1, 2, 4, 8]
 
 #Start with CPU benchmarks for 1 thread and add other results

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -10,7 +10,6 @@ BenchmarkTools.DEFAULT_PARAMETERS.seconds = 120
 
 # To run benchmarks on a specific GPU backend, add AMDGPU / CUDA / Metal / oneAPI
 # to benchmarks/Project.toml and change BENCHMARK_GROUP to the backend name.
-# oneAPI support is experimental and is disabled in CI benchmark publishing.
 const BENCHMARK_GROUP = get(ENV, "BENCHMARK_GROUP", "CPU")
 const BENCHMARK_CPU_THREADS = Threads.nthreads()
 


### PR DESCRIPTION
## Summary
- run oneAPI tests like the other backends
- include oneAPI in combined benchmarks when its artifact exists
- keep missing oneAPI benchmark artifacts non-fatal